### PR TITLE
Better support for text nodes

### DIFF
--- a/src/xml_element.cc
+++ b/src/xml_element.cc
@@ -280,6 +280,36 @@ NAN_METHOD(XmlElement::AddNextSibling) {
   NanReturnValue(args[0]);
 }
 
+NAN_METHOD(XmlElement::AddPrevText) {
+  NanScope();
+  XmlElement* element = ObjectWrap::Unwrap<XmlElement>(args.Holder());
+  assert(element);
+
+  v8::String::Utf8Value contentRaw(args[0]);
+  if(contentRaw.length() == 0) {
+    return NanThrowError("This method requires valid text.");
+  }
+
+  element->add_prev_text(*contentRaw);
+
+  NanReturnValue(args.Holder());
+}
+
+NAN_METHOD(XmlElement::AddNextText) {
+  NanScope();
+  XmlElement* element = ObjectWrap::Unwrap<XmlElement>(args.Holder());
+  assert(element);
+
+  v8::String::Utf8Value contentRaw(args[0]);
+  if(contentRaw.length() == 0) {
+    return NanThrowError("This method requires valid text.");
+  }
+
+  element->add_next_text(*contentRaw);
+
+  NanReturnValue(args.Holder());
+}
+
 void
 XmlElement::set_name(const char* name) {
   xmlNodeSetName(xml_obj, (const xmlChar*)name);
@@ -492,6 +522,32 @@ XmlElement::add_next_sibling(XmlElement* element) {
   xmlAddNextSibling(xml_obj, element->xml_obj);
 }
 
+void
+XmlElement::add_prev_text(const char* content) {
+  // v8::String::Utf8Value contentRaw(contentOpt);
+  // const char* content = (contentRaw.length()) ? *contentRaw : NULL;
+
+  xmlChar* encoded = content ? xmlEncodeSpecialChars(xml_obj->doc, (const xmlChar*)content) : NULL;
+  xmlNode* text_child = xmlNewDocText(xml_obj->doc, encoded);
+
+  if(encoded) {
+    xmlAddPrevSibling(xml_obj, text_child);
+  }
+}
+
+void
+XmlElement::add_next_text(const char* content) {
+  // v8::String::Utf8Value contentRaw(contentOpt);
+  // const char* content = (contentRaw.length()) ? *contentRaw : NULL;
+
+  xmlChar* encoded = content ? xmlEncodeSpecialChars(xml_obj->doc, (const xmlChar*)content) : NULL;
+  xmlNode* text_child = xmlNewDocText(xml_obj->doc, encoded);
+
+  if(encoded) {
+    xmlAddNextSibling(xml_obj, text_child);
+  }
+}
+
 XmlElement *
 XmlElement::import_element(XmlElement *element) {
 
@@ -583,6 +639,14 @@ XmlElement::Initialize(v8::Handle<v8::Object> target)
     NODE_SET_PROTOTYPE_METHOD(tmpl,
             "addNextSibling",
             XmlElement::AddNextSibling);
+
+    NODE_SET_PROTOTYPE_METHOD(tmpl,
+            "addPrevText",
+            XmlElement::AddPrevText);
+
+    NODE_SET_PROTOTYPE_METHOD(tmpl,
+            "addNextText",
+            XmlElement::AddNextText);
 
     target->Set(NanNew<v8::String>("Element"),
             tmpl->GetFunction());

--- a/src/xml_element.cc
+++ b/src/xml_element.cc
@@ -290,9 +290,9 @@ NAN_METHOD(XmlElement::AddPrevText) {
     return NanThrowError("This method requires valid text.");
   }
 
-  element->add_prev_text(*contentRaw);
+  xmlNode* text_child = element->add_prev_text(*contentRaw);
 
-  NanReturnValue(args.Holder());
+  return NanEscapeScope(XmlNode::New(text_child));
 }
 
 NAN_METHOD(XmlElement::AddNextText) {
@@ -305,9 +305,9 @@ NAN_METHOD(XmlElement::AddNextText) {
     return NanThrowError("This method requires valid text.");
   }
 
-  element->add_next_text(*contentRaw);
+  xmlNode* text_child = element->add_next_text(*contentRaw);
 
-  NanReturnValue(args.Holder());
+  return NanEscapeScope(XmlNode::New(text_child));
 }
 
 void
@@ -522,7 +522,7 @@ XmlElement::add_next_sibling(XmlElement* element) {
   xmlAddNextSibling(xml_obj, element->xml_obj);
 }
 
-void
+xmlNode*
 XmlElement::add_prev_text(const char* content) {
   // v8::String::Utf8Value contentRaw(contentOpt);
   // const char* content = (contentRaw.length()) ? *contentRaw : NULL;
@@ -531,11 +531,13 @@ XmlElement::add_prev_text(const char* content) {
   xmlNode* text_child = xmlNewDocText(xml_obj->doc, encoded);
 
   if(encoded) {
-    xmlAddPrevSibling(xml_obj, text_child);
+    text_child = xmlAddPrevSibling(xml_obj, text_child);
   }
+
+  return text_child;
 }
 
-void
+xmlNode*
 XmlElement::add_next_text(const char* content) {
   // v8::String::Utf8Value contentRaw(contentOpt);
   // const char* content = (contentRaw.length()) ? *contentRaw : NULL;
@@ -544,8 +546,10 @@ XmlElement::add_next_text(const char* content) {
   xmlNode* text_child = xmlNewDocText(xml_obj->doc, encoded);
 
   if(encoded) {
-    xmlAddNextSibling(xml_obj, text_child);
+    text_child = xmlAddNextSibling(xml_obj, text_child);
   }
+
+  return text_child;
 }
 
 XmlElement *

--- a/src/xml_element.h
+++ b/src/xml_element.h
@@ -58,8 +58,8 @@ protected:
     v8::Local<v8::Value> get_prev_element();
     void add_prev_sibling(XmlElement* element);
     void add_next_sibling(XmlElement* element);
-    void add_prev_text(const char* content);
-    void add_next_text(const char* content);
+    xmlNode* add_prev_text(const char* content);
+    xmlNode* add_next_text(const char* content);
 
     XmlElement *import_element(XmlElement* element);
 };

--- a/src/xml_element.h
+++ b/src/xml_element.h
@@ -31,6 +31,7 @@ protected:
     static NAN_METHOD(Child);
     static NAN_METHOD(ChildNodes);
     static NAN_METHOD(AddChild);
+    static NAN_METHOD(AddText);
     static NAN_METHOD(AddCData);
     static NAN_METHOD(NextElement);
     static NAN_METHOD(PrevElement);
@@ -47,6 +48,7 @@ protected:
     v8::Local<v8::Value> get_attrs();
     void set_attr(const char* name, const char* value);
     void add_child(XmlElement* child);
+    void add_text(xmlNode* text);
     void add_cdata(xmlNode* cdata);
     void set_content(const char* content);
     v8::Local<v8::Value> get_content();

--- a/src/xml_element.h
+++ b/src/xml_element.h
@@ -37,6 +37,8 @@ protected:
     static NAN_METHOD(PrevElement);
     static NAN_METHOD(AddPrevSibling);
     static NAN_METHOD(AddNextSibling);
+    static NAN_METHOD(AddPrevText);
+    static NAN_METHOD(AddNextText);
 
     void set_name(const char* name);
 
@@ -56,6 +58,9 @@ protected:
     v8::Local<v8::Value> get_prev_element();
     void add_prev_sibling(XmlElement* element);
     void add_next_sibling(XmlElement* element);
+    void add_prev_text(const char* content);
+    void add_next_text(const char* content);
+
     XmlElement *import_element(XmlElement* element);
 };
 

--- a/src/xml_element.h
+++ b/src/xml_element.h
@@ -50,7 +50,7 @@ protected:
     v8::Local<v8::Value> get_attrs();
     void set_attr(const char* name, const char* value);
     void add_child(XmlElement* child);
-    void add_text(xmlNode* text);
+    void add_text(const char* content);
     void add_cdata(xmlNode* cdata);
     void set_content(const char* content);
     v8::Local<v8::Value> get_content();

--- a/test/element.js
+++ b/test/element.js
@@ -99,6 +99,34 @@ module.exports.addChild = function(assert) {
     assert.done();
 };
 
+module.exports.addText = function(assert) {
+    var doc = libxml.Document();
+    var elem = doc.node('name1');
+
+    assert.equal('', elem.text());
+    elem.addText('text content');
+    assert.equal('text content', elem.text());
+
+    elem.addText(' more content');
+    assert.equal('text content more content', elem.text()
+        , 'subsequent calls are additive');
+
+    var children = elem.childNodes();
+    assert.equal(1, children.length
+        , 'multiple adjacent text nodes are merged');
+    assert.equal('text', children[0].type()
+        , 'nodes are of type text');
+
+    elem.node('name2');
+    elem.addText('content after element');
+    children = elem.childNodes();
+    assert.equal(3, children.length
+        , 'text separated by elements yields multiple text nodes');
+    assert.equal('content after element', children[2].text());
+
+    assert.done();
+};
+
 module.exports.add_prev_sibling = function(assert) {
     var doc = libxml.Document();
     var elem = doc.node('name1');

--- a/test/element.js
+++ b/test/element.js
@@ -165,8 +165,9 @@ module.exports.add_prev_text = function(assert) {
     var child2 = elem.node('child2');
     assert.equal(elem.childNodes().length, 2);
 
-    child2.addPrevText('previous text');
+    var node = child2.addPrevText('previous text');
     var children = elem.childNodes();
+    assert.equal(children[1], node, 'addPrevText returns the added text node');
     assert.equal(3, children.length);
     assert.equal('text', children[1].type());
     assert.equal('previous text', children[1].toString());
@@ -181,8 +182,9 @@ module.exports.add_next_text = function(assert) {
     var child2 = elem.node('child2');
     assert.equal(elem.childNodes().length, 2);
 
-    child2.addNextText('next text');
+    var node = child2.addNextText('next text');
     var children = elem.childNodes();
+    assert.equal(children[2], node, 'addNextText returns the added text node.');
     assert.equal(3, children.length);
     assert.equal('text', children[2].type());
     assert.equal('next text', children[2].toString());

--- a/test/element.js
+++ b/test/element.js
@@ -99,32 +99,61 @@ module.exports.addChild = function(assert) {
     assert.done();
 };
 
-module.exports.addText = function(assert) {
-    var doc = libxml.Document();
-    var elem = doc.node('name1');
+module.exports.addText = {
+    features: function(assert) {
+        var doc = libxml.Document();
+        var elem = doc.node('name1');
 
-    assert.equal('', elem.text());
-    elem.addText('text content');
-    assert.equal('text content', elem.text());
+        assert.equal('', elem.text());
+        elem.addText('text content');
+        assert.equal('text content', elem.text());
 
-    elem.addText(' more content');
-    assert.equal('text content more content', elem.text()
-        , 'subsequent calls are additive');
+        elem.addText(' more content');
+        assert.equal('text content more content', elem.text()
+            , 'subsequent calls are additive');
 
-    var children = elem.childNodes();
-    assert.equal(1, children.length
-        , 'multiple adjacent text nodes are merged');
-    assert.equal('text', children[0].type()
-        , 'nodes are of type text');
+        var children = elem.childNodes();
+        assert.equal(1, children.length
+            , 'multiple adjacent text nodes are merged');
+        assert.equal('text', children[0].type()
+            , 'nodes are of type text');
 
-    elem.node('name2');
-    elem.addText('content after element');
-    children = elem.childNodes();
-    assert.equal(3, children.length
-        , 'text separated by elements yields multiple text nodes');
-    assert.equal('content after element', children[2].text());
+        elem.node('name2');
+        elem.addText('content after element');
+        children = elem.childNodes();
+        assert.equal(3, children.length
+            , 'text separated by elements yields multiple text nodes');
+        assert.equal('content after element', children[2].text());
 
-    assert.done();
+        assert.done();
+    },
+    errors: function(assert) {
+        function assertBadArgError(func, msg) {
+            assert.throws(func, /^Bad argument/, msg);
+        }
+
+        var doc = libxml.parseXml('<doc><child1/><child2/></doc>');
+        var child = doc.get('//child1');
+
+        assertBadArgError(function() {
+            child.addText();
+        }, 'throws correct error on empty args');
+
+        assertBadArgError(function() {
+            child.addText('');
+
+        }, 'throws correct error on empty string');
+
+        assertBadArgError(function() {
+            child.addText(null);
+        }, 'throws correct error on null');
+
+        assertBadArgError(function() {
+            child.addText(undefined);
+        }, 'throws correct error on undefined');
+
+        assert.done();
+    }
 };
 
 module.exports.add_prev_sibling = function(assert) {
@@ -157,38 +186,96 @@ module.exports.add_next_sibling = function(assert) {
     assert.done();
 };
 
-module.exports.add_prev_text = function(assert) {
-    var doc = libxml.Document();
-    var elem = doc.node('name1');
+module.exports.add_prev_text = {
+    features: function(assert) {
+        var doc = libxml.Document();
+        var elem = doc.node('name1');
 
-    var child1 = elem.node('child1');
-    var child2 = elem.node('child2');
-    assert.equal(elem.childNodes().length, 2);
+        var child1 = elem.node('child1');
+        var child2 = elem.node('child2');
+        assert.equal(elem.childNodes().length, 2);
 
-    var node = child2.addPrevText('previous text');
-    var children = elem.childNodes();
-    assert.equal(children[1], node, 'addPrevText returns the added text node');
-    assert.equal(3, children.length);
-    assert.equal('text', children[1].type());
-    assert.equal('previous text', children[1].toString());
-    assert.done();
+        var node = child2.addPrevText('previous text');
+        var children = elem.childNodes();
+        assert.equal(children[1], node, 'addPrevText returns the added text node');
+        assert.equal(3, children.length);
+        assert.equal('text', children[1].type());
+        assert.equal('previous text', children[1].toString());
+
+        assert.done();
+    },
+    errors: function(assert) {
+        function assertBadArgError(func, msg) {
+            assert.throws(func, /^Bad argument/, msg);
+        }
+
+        var doc = libxml.parseXml('<doc><child1/><child2/></doc>');
+        var child = doc.get('//child1');
+
+        assertBadArgError(function() {
+            child.addPrevText();
+        }, 'throws correct error on empty args');
+
+        assertBadArgError(function() {
+            child.addPrevText('');
+        }, 'throws correct error on empty string');
+
+        assertBadArgError(function() {
+            child.addPrevText(null);
+        }, 'throws correct error on null');
+
+        assertBadArgError(function() {
+            child.addPrevText(undefined);
+        }, 'throws correct error on undefined');
+
+        assert.done();
+    }
 };
 
-module.exports.add_next_text = function(assert) {
-    var doc = libxml.Document();
-    var elem = doc.node('name1');
+module.exports.add_next_text = {
+    features: function(assert) {
+        var doc = libxml.Document();
+        var elem = doc.node('name1');
 
-    var child1 = elem.node('child1');
-    var child2 = elem.node('child2');
-    assert.equal(elem.childNodes().length, 2);
+        var child1 = elem.node('child1');
+        var child2 = elem.node('child2');
+        assert.equal(elem.childNodes().length, 2);
 
-    var node = child2.addNextText('next text');
-    var children = elem.childNodes();
-    assert.equal(children[2], node, 'addNextText returns the added text node.');
-    assert.equal(3, children.length);
-    assert.equal('text', children[2].type());
-    assert.equal('next text', children[2].toString());
-    assert.done();
+        var node = child2.addNextText('next text');
+        var children = elem.childNodes();
+        assert.equal(children[2], node, 'addNextText returns the added text node.');
+        assert.equal(3, children.length);
+        assert.equal('text', children[2].type());
+        assert.equal('next text', children[2].toString());
+
+        assert.done();
+    },
+    errors: function(assert) {
+        function assertBadArgError(func, msg) {
+            assert.throws(func, /^Bad argument/, msg);
+        }
+
+        var doc = libxml.parseXml('<doc><child1/><child2/></doc>');
+        var child = doc.get('//child1');
+
+        assertBadArgError(function() {
+            child.addNextText();
+        }, 'throws correct error on empty args');
+
+        assertBadArgError(function() {
+            child.addNextText('');
+        }, 'throws correct error on empty string');
+
+        assertBadArgError(function() {
+            child.addNextText(null);
+        }, 'throws correct error on null');
+
+        assertBadArgError(function() {
+            child.addNextText(undefined);
+        }, 'throws correct error on undefined');
+
+        assert.done();
+    }
 };
 
 module.exports.import = function(assert) {

--- a/test/element.js
+++ b/test/element.js
@@ -157,6 +157,38 @@ module.exports.add_next_sibling = function(assert) {
     assert.done();
 };
 
+module.exports.add_prev_text = function(assert) {
+    var doc = libxml.Document();
+    var elem = doc.node('name1');
+
+    var child1 = elem.node('child1');
+    var child2 = elem.node('child2');
+    assert.equal(elem.childNodes().length, 2);
+
+    child2.addPrevText('previous text');
+    var children = elem.childNodes();
+    assert.equal(3, children.length);
+    assert.equal('text', children[1].type());
+    assert.equal('previous text', children[1].toString());
+    assert.done();
+};
+
+module.exports.add_next_text = function(assert) {
+    var doc = libxml.Document();
+    var elem = doc.node('name1');
+
+    var child1 = elem.node('child1');
+    var child2 = elem.node('child2');
+    assert.equal(elem.childNodes().length, 2);
+
+    child2.addNextText('next text');
+    var children = elem.childNodes();
+    assert.equal(3, children.length);
+    assert.equal('text', children[2].type());
+    assert.equal('next text', children[2].toString());
+    assert.done();
+};
+
 module.exports.import = function(assert) {
     var doc = libxml.Document();
     var elem = doc.node('name1');


### PR DESCRIPTION
This is branch to add better support for adding text nodes per #263. The task list below outlines the steps needed for completion.

- [x] add `addText` method to append text nodes to an element.
- [x] add `addPrevText` and `addNextText`