### PR TITLE
Fix double free

### DIFF
--- a/src/xml_node.h
+++ b/src/xml_node.h
@@ -49,6 +49,13 @@ protected:
     v8::Local<v8::Value> get_type();
     v8::Local<v8::Value> to_string();
     void remove();
+
+private:
+    // by convention, any XmlNode * which has no parent is currently _owning_ its subtree
+    //
+    // This method should be called on destruction of such subtree-owner nodes, which will then
+    // promote new subtree owners by selecting the 'highest' nodes from all its children
+    static void free_untracked_child_nodes(xmlNode * const root);
 };
 
 }  // namespace libxmljs

--- a/test/ref_integrity.js
+++ b/test/ref_integrity.js
@@ -25,3 +25,26 @@ module.exports.references = function(assert) {
     assert.equal("child", nodes[1].name());
     assert.done();
 };
+
+// test that double-freeing XmlNode's doesn't cause a segfault
+module.exports.double_free = function(assert) {
+    var children = null;
+
+    // stick this portion of code into a self-executing function so
+    // its internal variables can be garbage collected
+    (function(){
+      var html = '<html><body><div><span></span></div></body></html>';
+      var doc = libxml.parseHtml(html);
+
+      doc.find('//div').forEach(function(tag){
+        // provide a reference to childNodes so they are exposed as XmlNodes
+        // and therefore subject to V8's garbage collection
+        children = tag.childNodes();
+        tag.remove();
+      });
+    })();
+
+    global.gc();
+    assert.ok( children[0].attrs() );
+    assert.done();
+};


### PR DESCRIPTION
Partially fixes: https://github.com/polotek/libxmljs/pull/163

After some exploration, it appears that `xmlFreeNode` actually recursively frees all children nodes.  If those children nodes have ObjectWrap'd wrappers pointing to them, we then have dangling `xml_obj`'s.  This PR addresses this by freeing those nodes only up to any nodes with `xml_obj->_private != NULL`.  This effectively promotes those nodes to the be the new "owners" of their subtrees.

Although this fixes the ref_integrity tests isolation, it seems to expose some more bugs in test/attribute.js.  I haven't been able to track those down yet.