### PR TITLE
Add .nsDecls API

### DIFF
--- a/src/xml_node.cc
+++ b/src/xml_node.cc
@@ -91,6 +91,14 @@ NAN_METHOD(XmlNode::Namespaces) {
   NanReturnValue(node->get_all_namespaces());
 }
 
+NAN_METHOD(XmlNode::NamespaceDeclarations) {
+  NanScope();
+  XmlNode* node = ObjectWrap::Unwrap<XmlNode>(args.Holder());
+  assert(node);
+
+  NanReturnValue(node->get_nsdefs());
+}
+
 NAN_METHOD(XmlNode::Parent) {
   NanScope();
   XmlNode* node = ObjectWrap::Unwrap<XmlNode>(args.Holder());
@@ -261,6 +269,21 @@ XmlNode::get_all_namespaces() {
 }
 
 v8::Local<v8::Value>
+XmlNode::get_nsdefs() {
+  NanEscapableScope();
+  xmlNs* nsDef = xml_obj->nsDef;
+
+  v8::Local<v8::Array> defs = NanNew<v8::Array>();
+  for(int i=0; nsDef; i++, nsDef = nsDef->next) {
+      v8::Local<v8::Number> index = NanNew<v8::Number>(i);
+      v8::Local<v8::Object> ns = XmlNamespace::New(nsDef);
+      defs->Set(index, ns);
+  }
+
+  return NanEscapeScope(defs);
+}
+
+v8::Local<v8::Value>
 XmlNode::get_parent() {
   NanEscapableScope();
 
@@ -411,6 +434,10 @@ XmlNode::Initialize(v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(tmpl,
                         "namespaces",
                         XmlNode::Namespaces);
+
+  NODE_SET_PROTOTYPE_METHOD(tmpl,
+                      "nsDecls",
+                      XmlNode::NamespaceDeclarations);
 
   NODE_SET_PROTOTYPE_METHOD(tmpl,
                         "prevSibling",

--- a/src/xml_node.h
+++ b/src/xml_node.h
@@ -26,6 +26,7 @@ protected:
     static NAN_METHOD(Doc);
     static NAN_METHOD(Namespace);
     static NAN_METHOD(Namespaces);
+    static NAN_METHOD(NamespaceDeclarations);
     static NAN_METHOD(Parent);
     static NAN_METHOD(NextSibling);
     static NAN_METHOD(PrevSibling);
@@ -41,6 +42,7 @@ protected:
     void set_namespace(xmlNs* ns);
     xmlNs * find_namespace(const char * search_str);
     v8::Local<v8::Value> get_all_namespaces();
+    v8::Local<v8::Value> get_nsdefs();
     v8::Local<v8::Value> get_parent();
     v8::Local<v8::Value> get_prev_sibling();
     v8::Local<v8::Value> get_next_sibling();

--- a/test/namespace.js
+++ b/test/namespace.js
@@ -168,3 +168,31 @@ module.exports.custom_ns = function(assert) {
   assert.equal(div.toString(), exp.toString());
   assert.done();
 }
+
+module.exports.decls = function(assert) {
+  var str = '<html xmlns="urn:example" xmlns:ex1="urn:example:1"><body/></html>';
+  var doc = libxml.parseXmlString(str);
+  assert.ok(doc);
+  var root = doc.root();
+  assert.ok(root);
+  var decls = root.nsDecls()
+  assert.ok(decls);
+  assert.equal(2, decls.length);
+  decls.forEach(function(n) {
+    if (n.prefix()==null) {
+      assert.equal("urn:example", n.href());
+    }
+    else if (n.prefix() == "ex1") {
+      assert.equal("urn:example:1", n.href());
+    }
+    else {
+      assert.ok(false);
+    }
+  });
+  // body has a namespace, from the default declaration on html.
+  var body = root.get('ex:body', {ex: 'urn:example'});
+  assert.ok(body);
+  decls = body.nsDecls();
+  assert.equal(0, decls.length);
+  assert.done();
+};


### PR DESCRIPTION
Fixes #270.  New API:

```javascript
  var str = '<html xmlns="urn:example" xmlns:ex1="urn:example:1"><body/></html>';
  var doc = libxml.parseXmlString(str);
  var root = doc.root();
  var decls = root.nsDecls()
```

`decls` now includes two namespace objects.  Applying to the body element yields an empty array.

Tests included.  I'll add docs to the wiki if you take the patch.  I'm open to renaming the API anything you like.