### PR TITLE
update nan to 1.5.1 and fix issues with the latest v8

### DIFF
--- a/lib/sax_parser.js
+++ b/lib/sax_parser.js
@@ -1,5 +1,4 @@
 var events = require('events');
-var util = require('util');
 
 var bindings = require('./bindings');
 
@@ -14,12 +13,10 @@ var SaxParser = function(callbacks) {
     return parser;
 };
 
-// store existing functions because util.inherits overrides the prototype
-var parseString = bindings.SaxParser.prototype.parseString;
-
-util.inherits(bindings.SaxParser, events.EventEmitter);
-
-bindings.SaxParser.prototype.parseString = parseString;
+// Overriding the prototype, like util.inherit, wipes out the native binding.
+// Copy over the methods instead.
+for (var k in events.EventEmitter.prototype)
+    bindings.SaxParser.prototype[k] = events.EventEmitter.prototype[k];
 
 var SaxPushParser = function(callbacks) {
     var parser = new bindings.SaxPushParser();
@@ -32,11 +29,10 @@ var SaxPushParser = function(callbacks) {
     return parser;
 };
 
-var push = bindings.SaxPushParser.prototype.push;
-
-util.inherits(bindings.SaxPushParser, events.EventEmitter);
-
-bindings.SaxPushParser.prototype.push = push;
+// Overriding the prototype, like util.inherit, wipes out the native binding.
+// Copy over the methods instead.
+for (var k in events.EventEmitter.prototype)
+    bindings.SaxPushParser.prototype[k] = events.EventEmitter.prototype[k];
 
 module.exports.SaxParser = SaxParser;
 module.exports.SaxPushParser = SaxPushParser;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bindings": "1.1.1",
-    "nan": "1.1.2"
+    "nan": "1.5.1"
   },
   "devDependencies": {
     "nodeunit": "0.9.0"

--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -47,6 +47,12 @@ void xmlMemFreeWrap(void* p)
     // our cleanup routines for libxml will be called (freeing memory)
     // but v8 is already offline and does not need to be informed
     // trying to adjust after shutdown will result in a fatal error
+#if (NODE_MODULE_VERSION > 0x000B)
+    if (v8::Isolate::GetCurrent() == 0)
+    {
+        return;
+    }
+#endif
     if (v8::V8::IsDead())
     {
         return;

--- a/src/xml_comment.cc
+++ b/src/xml_comment.cc
@@ -82,7 +82,7 @@ XmlComment::get_content() {
     return NanEscapeScope(ret_content);
   }
 
-  return NanEscapeScope(NanNew<v8::String>());
+  return NanEscapeScope(NanNew<v8::String>(""));
 }
 
 
@@ -109,7 +109,7 @@ void
 XmlComment::Initialize(v8::Handle<v8::Object> target)
 {
     NanScope();
-    v8::Local<v8::FunctionTemplate> t = NanNew<v8::FunctionTemplate>(New);
+    v8::Local<v8::FunctionTemplate> t = NanNew<v8::FunctionTemplate>(static_cast<NAN_METHOD((*))>(New));
     t->Inherit(NanNew(XmlNode::constructor_template));
     t->InstanceTemplate()->SetInternalFieldCount(1);
     NanAssignPersistent(constructor_template, t);

--- a/src/xml_element.cc
+++ b/src/xml_element.cc
@@ -397,7 +397,7 @@ XmlElement::get_content() {
     return ret_content;
   }
 
-  return NanNew<v8::String>();
+  return NanNew<v8::String>("");
 }
 
 v8::Local<v8::Value>

--- a/src/xml_node.cc
+++ b/src/xml_node.cc
@@ -294,7 +294,7 @@ XmlNode::get_next_sibling() {
 v8::Local<v8::Value>
 XmlNode::get_line_number() {
   NanEscapableScope();
-  return NanEscapeScope(NanNew<v8::Integer>(xmlGetLineNo(xml_obj)));
+  return NanEscapeScope(NanNew<v8::Integer>(uint32_t(xmlGetLineNo(xml_obj))));
 }
 
 v8::Local<v8::Value>


### PR DESCRIPTION
This updates nan to the latest and fixes some issues so that the module can work with the io.js 1.0.1 release.

Most changes are pretty trivial. sax_parser.js had to change the way it inherits from EventEmitter because the old way would cause an assertion trying to set up the ObjectWrap.