### PR TITLE
Add .namespace() to Attribute

### DIFF
--- a/src/xml_attribute.cc
+++ b/src/xml_attribute.cc
@@ -73,6 +73,14 @@ NAN_METHOD(XmlAttribute::Node) {
   NanReturnValue(attr->get_element());
 }
 
+NAN_METHOD(XmlAttribute::Namespace) {
+  NanScope();
+  XmlAttribute *attr = ObjectWrap::Unwrap<XmlAttribute>(args.Holder());
+  assert(attr);
+
+  NanReturnValue(attr->get_namespace());
+}
+
 v8::Local<v8::Value>
 XmlAttribute::get_name() {
   if (xml_obj->name)
@@ -131,6 +139,14 @@ XmlAttribute::get_element() {
     return XmlElement::New(xml_obj->parent);
 }
 
+v8::Local<v8::Value>
+XmlAttribute::get_namespace() {
+    if (!xml_obj->ns) {
+        return NanNull();
+    }
+    return XmlNamespace::New(xml_obj->ns);
+}
+
 void
 XmlAttribute::Initialize(v8::Handle<v8::Object> target) {
   NanScope();
@@ -143,6 +159,7 @@ XmlAttribute::Initialize(v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(tmpl, "name", XmlAttribute::Name);
   NODE_SET_PROTOTYPE_METHOD(tmpl, "value", XmlAttribute::Value);
   NODE_SET_PROTOTYPE_METHOD(tmpl, "node", XmlAttribute::Node);
+  NODE_SET_PROTOTYPE_METHOD(tmpl, "namespace", XmlAttribute::Namespace);
 
   target->Set(NanNew<v8::String>("Attribute"),
               tmpl->GetFunction());

--- a/src/xml_attribute.h
+++ b/src/xml_attribute.h
@@ -28,11 +28,13 @@ protected:
     static NAN_METHOD(Name);
     static NAN_METHOD(Value);
     static NAN_METHOD(Node);
+    static NAN_METHOD(Namespace);
 
     v8::Local<v8::Value> get_name();
     v8::Local<v8::Value> get_value();
     void set_value(const char* value);
     v8::Local<v8::Value> get_element();
+    v8::Local<v8::Value> get_namespace();
 };
 
 }  // namespace libxmljs

--- a/test/element.js
+++ b/test/element.js
@@ -157,3 +157,25 @@ module.exports.clone = function(assert) {
     assert.equal(elem.toString(), elem2.toString());
     assert.done();
 };
+
+module.exports.namespace = function(assert) {
+    var str = '<?xml version="1.0" encoding="UTF-8"?>\n'+
+            '<root xmlns:bacon="http://www.example.com/fake/uri"><node bacon:attr-with-ns="attr-with-ns-value" attr-without-ns="attr-withoug-ns-vavlue" /></root>';
+    var doc = new libxml.parseXml(str);
+    var node = doc.get('node');
+    var attrs = node.attrs();
+
+    attrs.forEach(function(attr) {
+        var name = attr.name();
+        var ns = attr.namespace();
+
+        if (name === 'attr-with-ns') {
+            assert.equal(ns.prefix(), 'bacon');
+            assert.equal(ns.href(), 'http://www.example.com/fake/uri');
+        } else {
+            assert.equal(name, 'attr-without-ns');
+            assert.equal(ns, null);
+        }
+    });
+    assert.done();
+};


### PR DESCRIPTION
Proposal to #201 

This is useful to treat attribute with namespace.

Example:
```javascript
var libxmljs = require('./index.js');

var xml = '<root ' +
      'xmlns:foo="http://www.example.com/fake/uri/foo"' +
      'xmlns:bar="http://www.example.com/fake/uri/bar"' +
      '>' +
      '<node foo:attr="foo value" bar:attr="bar value" />' +
      '</root>';

var doc = new libxmljs.parseXmlString(xml);
var node = doc.get('node');
var attrs = node.attrs();

attrs.forEach(function(attr) {
  console.log(attr.namespace().prefix() + ':' + attr.name() + '="' + attr.value() + '"');
});
```

Output:
```
foo:attr="foo value"
bar:attr="bar value"
```