### PR TITLE
Add xinclude support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,7 +19,8 @@
       ],
       'dependencies': [
         './vendor/libxml/libxml.gyp:libxml'
-      ]
+      ],
+      'defines': ['LIBXML_XINCLUDE_ENABLED']
     }
   ]
 }

--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -8,6 +8,7 @@
 #include <libxml/HTMLparser.h>
 #include <libxml/xmlschemas.h>
 #include <libxml/relaxng.h>
+#include <libxml/xinclude.h>
 
 #include "xml_document.h"
 #include "xml_element.h"
@@ -337,6 +338,12 @@ NAN_METHOD(XmlDocument::FromXml)
             return NanThrowError(XmlSyntaxError::BuildSyntaxError(error));
         }
         return NanThrowError("Could not parse XML string");
+    }
+
+    if (opts & XML_PARSE_XINCLUDE) {
+      if (xmlXIncludeProcessFlags(doc, opts) < 0) {
+        return NanThrowError("Could not process XIncludes");
+      }
     }
 
     v8::Local<v8::Object> doc_handle = XmlDocument::New(doc);

--- a/vendor/libxml/libxml.gyp
+++ b/vendor/libxml/libxml.gyp
@@ -17,6 +17,7 @@
         'HTMLtree.c',
         'legacy.c',
         'list.c',
+        'nanohttp.c',
         'parser.c',
         'parserInternals.c',
         'pattern.c',
@@ -51,6 +52,7 @@
           'include/',
         ],
       },
+      'defines': ['LIBXML_XINCLUDE_ENABLED', 'LIBXML_HTTP_ENABLED'],
     }
   ]
 }


### PR DESCRIPTION
The option processing was already there for it, but it wasn't turned on.

Note: this *does* enable nanohttp, which is potentially unwanted; we might prefer to use node's HTTP stack.  However, that would likely mean making an async version of parseXml, which seemed like a larger change than I wanted to make without discussing it with you first.