### PR TITLE
Get Travis to build for iojs as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
     - "0.8"
     - "0.10"
     - "0.12"
+    - iojs
 
 before_install:
-  - npm update -g npm
+    - case ${TRAVIS_NODE_VERSION} in 0.8*|0.10*) npm update -g npm ;; esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ node_js:
     - "0.8"
     - "0.10"
     - "0.12"
-    - iojs
+    - iojs-2.0
+    - iojs-2
 
 before_install:
     - case ${TRAVIS_NODE_VERSION} in 0.8*|0.10*) npm update -g npm ;; esac


### PR DESCRIPTION
Do you want Travis to build against io.js?

The problem with `node-gyp` not working with iojs can be solved by using the version shipped with iojs, not the version from the latest npm we install separately.  See https://github.com/nodejs/io.js/issues/433 for details. So we update npm to latest upstream only for old versions of node.js, not for the current version or for iojs.