### PR TITLE
Fix segfaults in destructor using `xmlDeregisterNodeDefault` callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
     - "0.8"
     - "0.10"
     - "0.11"
+before_install:
+  - npm install npm
+  - mv node_modules npm
+  - npm/.bin/npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
     - "0.8"
     - "0.10"
     - "0.11"
+
 before_install:
-  - npm install npm
-  - mv node_modules npm
-  - npm/.bin/npm install
+  - npm update -g npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
     - "0.8"
     - "0.10"
-    - "0.11"
+    - "0.12"
 
 before_install:
   - npm update -g npm

--- a/binding.gyp
+++ b/binding.gyp
@@ -19,6 +19,17 @@
       ],
       'dependencies': [
         './vendor/libxml/libxml.gyp:libxml'
+      ],
+      'conditions': [
+        ['OS=="mac"', {
+          # node-gyp 2.x doesn't add this anymore
+          # https://github.com/TooTallNate/node-gyp/pull/612
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              '-undefined dynamic_lookup'
+            ],
+          },
+        }]
       ]
     }
   ]

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports.version = require('./package.json').version;
 module.exports.libxml_version = bindings.libxml_version;
 module.exports.libxml_parser_version = bindings.libxml_parser_version;
 module.exports.libxml_debug_enabled = bindings.libxml_debug_enabled;
+module.exports.features = bindings.features;
 
 // lib exports
 module.exports.Document = Document;

--- a/lib/document.js
+++ b/lib/document.js
@@ -2,6 +2,12 @@ var bindings = require('./bindings');
 
 var Element = require('./element');
 
+function assertRoot(doc) {
+    if(!doc.root()) {
+        throw new Error('Document has no root element');
+    }
+}
+
 /// Create a new document
 /// @param {string} version xml version, default 1.0
 /// @param {string} encoding the encoding, default utf8
@@ -31,12 +37,16 @@ Document.prototype.node = function(name, content) {
 /// xpath search
 /// @return array of matching elements
 Document.prototype.find = function(xpath, ns_uri) {
+    assertRoot(this);
+
     return this.root().find(xpath, ns_uri);
 };
 
 /// xpath search
 /// @return first element matching
 Document.prototype.get = function(xpath, ns_uri) {
+    assertRoot(this);
+
     return this.root().get(xpath, ns_uri);
 };
 
@@ -45,11 +55,16 @@ Document.prototype.child = function(id) {
     if (id === undefined || typeof id !== 'number') {
         throw new Error('id argument required for #child');
     }
+
+    assertRoot(this);
+
     return this.root().child(id);
 };
 
 /// @return an Array of child nodes of the document root
 Document.prototype.childNodes = function() {
+    assertRoot(this);
+
     return this.root().childNodes();
 };
 
@@ -97,6 +112,8 @@ Document.prototype.setDtd = function(name, ext, sys) {
 
 /// @return array of namespaces in document
 Document.prototype.namespaces = function() {
+    assertRoot(this);
+
     return this.root().namespaces();
 };
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -88,6 +88,11 @@ Document.prototype.validate = function(xsd) {
     return this._validate(xsd);
 };
 
+/// @return whether the XmlDocument is valid using Relaxed NG
+Document.prototype.rngValidate = function(rng) {
+    return this._rngValidate(rng);
+};
+
 Document.prototype.getDtd = function() {
     return this._getDtd();
 };

--- a/lib/sax_parser.js
+++ b/lib/sax_parser.js
@@ -1,5 +1,4 @@
 var events = require('events');
-var util = require('util');
 
 var bindings = require('./bindings');
 
@@ -14,12 +13,10 @@ var SaxParser = function(callbacks) {
     return parser;
 };
 
-// store existing functions because util.inherits overrides the prototype
-var parseString = bindings.SaxParser.prototype.parseString;
-
-util.inherits(bindings.SaxParser, events.EventEmitter);
-
-bindings.SaxParser.prototype.parseString = parseString;
+// Overriding the prototype, like util.inherit, wipes out the native binding.
+// Copy over the methods instead.
+for (var k in events.EventEmitter.prototype)
+    bindings.SaxParser.prototype[k] = events.EventEmitter.prototype[k];
 
 var SaxPushParser = function(callbacks) {
     var parser = new bindings.SaxPushParser();
@@ -32,11 +29,10 @@ var SaxPushParser = function(callbacks) {
     return parser;
 };
 
-var push = bindings.SaxPushParser.prototype.push;
-
-util.inherits(bindings.SaxPushParser, events.EventEmitter);
-
-bindings.SaxPushParser.prototype.push = push;
+// Overriding the prototype, like util.inherit, wipes out the native binding.
+// Copy over the methods instead.
+for (var k in events.EventEmitter.prototype)
+    bindings.SaxPushParser.prototype[k] = events.EventEmitter.prototype[k];
 
 module.exports.SaxParser = SaxParser;
 module.exports.SaxPushParser = SaxPushParser;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "Jeff Smick"
   ],
   "description": "libxml bindings for v8 javascript engine",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "scripts": {
     "test": "node --expose_gc ./node_modules/.bin/nodeunit test"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "Jeff Smick"
   ],
   "description": "libxml bindings for v8 javascript engine",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "scripts": {
     "test": "node --expose_gc ./node_modules/.bin/nodeunit test"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bindings": "1.1.1",
-    "nan": "1.1.2"
+    "nan": "1.5.1"
   },
   "devDependencies": {
     "nodeunit": "0.9.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "http://github.com/polotek/libxmljs/issues"
   },
   "main": "./index",
+  "license": "MIT",
   "engines": {
     "node": ">=0.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "bindings": "1.1.1",
-    "nan": "1.5.1"
+    "bindings": "1.2.1",
+    "nan": "1.7.0"
   },
   "devDependencies": {
     "nodeunit": "0.9.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "Jeff Smick"
   ],
   "description": "libxml bindings for v8 javascript engine",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "scripts": {
     "test": "node --expose_gc ./node_modules/.bin/nodeunit test"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "Jeff Smick"
   ],
   "description": "libxml bindings for v8 javascript engine",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "scripts": {
     "test": "node --expose_gc ./node_modules/.bin/nodeunit test"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bindings": "1.2.1",
-    "nan": "1.7.0"
+    "nan": "1.8.4"
   },
   "devDependencies": {
     "nodeunit": "0.9.0"

--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -117,6 +117,47 @@ LibXMLJS::~LibXMLJS()
     xmlCleanupParser();
 }
 
+v8::Local<v8::Object> listFeatures() {
+    v8::Local<v8::Object> target = NanNew<v8::Object>();
+#define FEAT(x) target->Set(NanNew<v8::String>(# x), \
+                    NanNew<v8::Boolean>(xmlHasFeature(XML_WITH_ ## x)))
+    // See enum xmlFeature in parser.h
+    FEAT(THREAD);
+    FEAT(TREE);
+    FEAT(OUTPUT);
+    FEAT(PUSH);
+    FEAT(READER);
+    FEAT(PATTERN);
+    FEAT(WRITER);
+    FEAT(SAX1);
+    FEAT(FTP);
+    FEAT(HTTP);
+    FEAT(VALID);
+    FEAT(HTML);
+    FEAT(LEGACY);
+    FEAT(C14N);
+    FEAT(CATALOG);
+    FEAT(XPATH);
+    FEAT(XPTR);
+    FEAT(XINCLUDE);
+    FEAT(ICONV);
+    FEAT(ISO8859X);
+    FEAT(UNICODE);
+    FEAT(REGEXP);
+    FEAT(AUTOMATA);
+    FEAT(EXPR);
+    FEAT(SCHEMAS);
+    FEAT(SCHEMATRON);
+    FEAT(MODULES);
+    FEAT(DEBUG);
+    FEAT(DEBUG_MEM);
+    FEAT(DEBUG_RUN);
+    FEAT(ZLIB);
+    FEAT(ICU);
+    FEAT(LZMA);
+    return target;
+}
+
 // used by node.js to initialize libraries
 extern "C" void
 init(v8::Handle<v8::Object> target)
@@ -134,6 +175,8 @@ init(v8::Handle<v8::Object> target)
 
       target->Set(NanNew<v8::String>("libxml_debug_enabled"),
                   NanNew<v8::Boolean>(debugging));
+
+      target->Set(NanNew<v8::String>("features"), listFeatures());
 
       target->Set(NanNew<v8::String>("libxml"), target);
 }

--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -47,6 +47,12 @@ void xmlMemFreeWrap(void* p)
     // our cleanup routines for libxml will be called (freeing memory)
     // but v8 is already offline and does not need to be informed
     // trying to adjust after shutdown will result in a fatal error
+#if (NODE_MODULE_VERSION > 0x000B)
+    if (v8::Isolate::GetCurrent() == 0)
+    {
+        return;
+    }
+#endif
     if (v8::V8::IsDead())
     {
         return;

--- a/src/xml_attribute.cc
+++ b/src/xml_attribute.cc
@@ -73,6 +73,14 @@ NAN_METHOD(XmlAttribute::Node) {
   NanReturnValue(attr->get_element());
 }
 
+NAN_METHOD(XmlAttribute::Namespace) {
+  NanScope();
+  XmlAttribute *attr = ObjectWrap::Unwrap<XmlAttribute>(args.Holder());
+  assert(attr);
+
+  NanReturnValue(attr->get_namespace());
+}
+
 v8::Local<v8::Value>
 XmlAttribute::get_name() {
   if (xml_obj->name)
@@ -131,6 +139,14 @@ XmlAttribute::get_element() {
     return XmlElement::New(xml_obj->parent);
 }
 
+v8::Local<v8::Value>
+XmlAttribute::get_namespace() {
+    if (!xml_obj->ns) {
+        return NanNull();
+    }
+    return XmlNamespace::New(xml_obj->ns);
+}
+
 void
 XmlAttribute::Initialize(v8::Handle<v8::Object> target) {
   NanScope();
@@ -143,6 +159,7 @@ XmlAttribute::Initialize(v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(tmpl, "name", XmlAttribute::Name);
   NODE_SET_PROTOTYPE_METHOD(tmpl, "value", XmlAttribute::Value);
   NODE_SET_PROTOTYPE_METHOD(tmpl, "node", XmlAttribute::Node);
+  NODE_SET_PROTOTYPE_METHOD(tmpl, "namespace", XmlAttribute::Namespace);
 
   target->Set(NanNew<v8::String>("Attribute"),
               tmpl->GetFunction());

--- a/src/xml_attribute.cc
+++ b/src/xml_attribute.cc
@@ -15,6 +15,7 @@ v8::Local<v8::Object>
 XmlAttribute::New(xmlNode* xml_obj, const xmlChar* name, const xmlChar* value)
 {
     xmlAttr* attr = xmlSetProp(xml_obj, name, value);
+    assert(attr);
 
     if (attr->_private) {
         return NanObjectWrapHandle(static_cast<XmlNode*>(xml_obj->_private));

--- a/src/xml_attribute.cc
+++ b/src/xml_attribute.cc
@@ -151,7 +151,7 @@ void
 XmlAttribute::Initialize(v8::Handle<v8::Object> target) {
   NanScope();
   v8::Local<v8::FunctionTemplate> tmpl =
-   NanNew<v8::FunctionTemplate, NanFunctionCallback>(XmlAttribute::New);
+   NanNew<v8::FunctionTemplate>(XmlAttribute::New);
   NanAssignPersistent(constructor_template, tmpl);
   tmpl->Inherit(NanNew(XmlNode::constructor_template));
   tmpl->InstanceTemplate()->SetInternalFieldCount(1);

--- a/src/xml_attribute.h
+++ b/src/xml_attribute.h
@@ -28,11 +28,13 @@ protected:
     static NAN_METHOD(Name);
     static NAN_METHOD(Value);
     static NAN_METHOD(Node);
+    static NAN_METHOD(Namespace);
 
     v8::Local<v8::Value> get_name();
     v8::Local<v8::Value> get_value();
     void set_value(const char* value);
     v8::Local<v8::Value> get_element();
+    v8::Local<v8::Value> get_namespace();
 };
 
 }  // namespace libxmljs

--- a/src/xml_comment.cc
+++ b/src/xml_comment.cc
@@ -82,7 +82,7 @@ XmlComment::get_content() {
     return NanEscapeScope(ret_content);
   }
 
-  return NanEscapeScope(NanNew<v8::String>());
+  return NanEscapeScope(NanNew<v8::String>(""));
 }
 
 
@@ -109,7 +109,7 @@ void
 XmlComment::Initialize(v8::Handle<v8::Object> target)
 {
     NanScope();
-    v8::Local<v8::FunctionTemplate> t = NanNew<v8::FunctionTemplate>(New);
+    v8::Local<v8::FunctionTemplate> t = NanNew<v8::FunctionTemplate>(static_cast<NAN_METHOD((*))>(New));
     t->Inherit(NanNew(XmlNode::constructor_template));
     t->InstanceTemplate()->SetInternalFieldCount(1);
     NanAssignPersistent(constructor_template, t);

--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -450,7 +450,7 @@ XmlDocument::Initialize(v8::Handle<v8::Object> target)
     NanScope();
 
     v8::Local<v8::FunctionTemplate> tmpl =
-      NanNew<v8::FunctionTemplate, NanFunctionCallback>(New);
+      NanNew<v8::FunctionTemplate>(New);
     tmpl->SetClassName(NanNew<v8::String>("Document"));
 
     NanAssignPersistent(constructor_template, tmpl);

--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -7,6 +7,7 @@
 
 #include <libxml/HTMLparser.h>
 #include <libxml/xmlschemas.h>
+#include <libxml/relaxng.h>
 
 #include "xml_document.h"
 #include "xml_element.h"
@@ -382,6 +383,40 @@ NAN_METHOD(XmlDocument::Validate)
     NanReturnValue(NanNew<v8::Boolean>(valid));
 }
 
+NAN_METHOD(XmlDocument::RngValidate)
+{
+    NanScope();
+
+    v8::Local<v8::Array> errors = NanNew<v8::Array>();
+    xmlResetLastError();
+    xmlSetStructuredErrorFunc(reinterpret_cast<void *>(&errors),
+            XmlSyntaxError::PushToArray);
+
+    XmlDocument* document = ObjectWrap::Unwrap<XmlDocument>(args.Holder());
+    XmlDocument* documentSchema = ObjectWrap::Unwrap<XmlDocument>(args[0]->ToObject());
+
+	xmlRelaxNGParserCtxtPtr parser_ctxt = xmlRelaxNGNewDocParserCtxt(documentSchema->xml_obj);
+    if (parser_ctxt == NULL) {
+        return NanThrowError("Could not create context for RELAX NG schema parser");
+    }
+
+	xmlRelaxNGPtr schema = xmlRelaxNGParse(parser_ctxt);
+    if (schema == NULL) {
+        return NanThrowError("Invalid RELAX NG schema");
+    }
+
+	xmlRelaxNGValidCtxtPtr valid_ctxt = xmlRelaxNGNewValidCtxt(schema);
+    if (valid_ctxt == NULL) {
+        return NanThrowError("Unable to create a validation context for the RELAX NG schema");
+    }
+	bool valid = xmlRelaxNGValidateDoc(valid_ctxt, document->xml_obj) == 0;
+
+    xmlSetStructuredErrorFunc(NULL, NULL);
+    args.Holder()->Set(NanNew<v8::String>("validationErrors"), errors);
+
+    NanReturnValue(NanNew<v8::Boolean>(valid));
+}
+
 /// this is a blank object with prototype methods
 /// not exposed to the user and not called from js
 NAN_METHOD(XmlDocument::New)
@@ -441,6 +476,9 @@ XmlDocument::Initialize(v8::Handle<v8::Object> target)
     NODE_SET_PROTOTYPE_METHOD(tmpl,
             "_validate",
             XmlDocument::Validate);
+    NODE_SET_PROTOTYPE_METHOD(tmpl,
+            "_rngValidate",
+            XmlDocument::RngValidate);
     NODE_SET_PROTOTYPE_METHOD(tmpl,
             "_setDtd",
             XmlDocument::SetDtd);

--- a/src/xml_document.h
+++ b/src/xml_document.h
@@ -53,6 +53,7 @@ protected:
     static NAN_METHOD(Errors);
     static NAN_METHOD(ToString);
     static NAN_METHOD(Validate);
+    static NAN_METHOD(RngValidate);	
 };
 
 }  // namespace libxmljs

--- a/src/xml_element.cc
+++ b/src/xml_element.cc
@@ -397,7 +397,7 @@ XmlElement::get_content() {
     return ret_content;
   }
 
-  return NanNew<v8::String>();
+  return NanNew<v8::String>("");
 }
 
 v8::Local<v8::Value>

--- a/src/xml_element.cc
+++ b/src/xml_element.cc
@@ -492,7 +492,7 @@ XmlElement::Initialize(v8::Handle<v8::Object> target)
 {
     NanScope();
     v8::Local<v8::FunctionTemplate> tmpl =
-      NanNew<v8::FunctionTemplate, NanFunctionCallback>(New);
+      NanNew<v8::FunctionTemplate>(New);
     NanAssignPersistent(constructor_template, tmpl);
     tmpl->Inherit(NanNew(XmlNode::constructor_template));
     tmpl->InstanceTemplate()->SetInternalFieldCount(1);

--- a/src/xml_namespace.cc
+++ b/src/xml_namespace.cc
@@ -127,7 +127,7 @@ void
 XmlNamespace::Initialize(v8::Handle<v8::Object> target) {
   NanScope();
   v8::Local<v8::FunctionTemplate> tmpl =
-    NanNew<v8::FunctionTemplate, NanFunctionCallback>(New);
+    NanNew<v8::FunctionTemplate>(New);
   NanAssignPersistent(constructor_template, tmpl);
   tmpl->InstanceTemplate()->SetInternalFieldCount(1);
 

--- a/src/xml_node.cc
+++ b/src/xml_node.cc
@@ -294,7 +294,7 @@ XmlNode::get_next_sibling() {
 v8::Local<v8::Value>
 XmlNode::get_line_number() {
   NanEscapableScope();
-  return NanEscapeScope(NanNew<v8::Integer>(xmlGetLineNo(xml_obj)));
+  return NanEscapeScope(NanNew<v8::Integer>(uint32_t(xmlGetLineNo(xml_obj))));
 }
 
 v8::Local<v8::Value>

--- a/test/document.js
+++ b/test/document.js
@@ -230,6 +230,60 @@ module.exports.validate = function(assert) {
     assert.done();
 };
 
+module.exports.rngValidate = function(assert) {
+	// see http://relaxng.org/ for more infos about RELAX NG
+
+	var rng =
+		'<element name="addressBook" xmlns="http://relaxng.org/ns/structure/1.0">'+
+			'<zeroOrMore>'+
+				'<element name="card">'+
+					'<element name="name">'+
+						'<text/>'+
+					'</element>'+
+					'<element name="email">'+
+						'<text/>'+
+					'</element>'+
+				'</element>'+
+			'</zeroOrMore>'+
+		'</element>';
+
+	var xml_valid = 
+		'<addressBook>'+
+			'<card>'+
+				'<name>John Smith</name>'+
+				'<email>js@example.com</email>'+
+			'</card>'+
+			'<card>'+
+				'<name>Fred Bloggs</name>'+
+				'<email>fb@example.net</email>'+
+			'</card>'+
+		'</addressBook>';
+
+	var xml_invalid = 
+		'<addressBook>'+
+			'<card>'+
+				'<Name>John Smith</Name>'+
+				'<email>js@example.com</email>'+
+			'</card>'+
+			'<card>'+
+				'<name>Fred Bloggs</name>'+
+				'<email>fb@example.net</email>'+
+			'</card>'+
+		'</addressBook>';
+
+    var rngDoc = libxml.parseXml(rng);
+    var xmlDocValid = libxml.parseXml(xml_valid);
+    var xmlDocInvalid = libxml.parseXml(xml_invalid);
+	
+    assert.equal(xmlDocValid.rngValidate(rngDoc), true);
+    assert.equal(xmlDocValid.validationErrors.length, 0);
+
+    assert.equal(xmlDocInvalid.rngValidate(rngDoc), false);
+    assert.equal(xmlDocInvalid.validationErrors.length, 1);
+
+    assert.done();
+};
+
 module.exports.errors = {
     empty_html_doc: function(assert) {
         function assertDocRootError(func, msg) {

--- a/test/document.js
+++ b/test/document.js
@@ -228,4 +228,38 @@ module.exports.validate = function(assert) {
     assert.equal(xmlDocInvalid.validationErrors.length, 1);
 
     assert.done();
-}
+};
+
+module.exports.errors = {
+    empty_html_doc: function(assert) {
+        function assertDocRootError(func, msg) {
+            assert.throws(func, /Document has no root element/, msg);
+        }
+
+        var xml_only_comments = '<!-- empty -->';
+        var doc = libxml.parseHtmlString(xml_only_comments);
+        assert.equal(null, doc.root());
+
+        assertDocRootError(function() {
+            doc.get('*');
+        }, 'get method throws correct error on empty doc');
+
+        assertDocRootError(function() {
+            doc.find('*');
+        }, 'find method throws correct error on empty doc');
+
+        assertDocRootError(function() {
+            doc.child(1);
+        }, 'child method throws correct error on empty doc');
+
+        assertDocRootError(function() {
+            doc.childNodes();
+        }, 'childNodes method throws correct error on empty doc');
+
+        assertDocRootError(function() {
+            doc.namespaces();
+        }, 'namespaces method throws correct error on empty doc');
+
+        assert.done();
+    }
+};

--- a/test/element.js
+++ b/test/element.js
@@ -157,3 +157,25 @@ module.exports.clone = function(assert) {
     assert.equal(elem.toString(), elem2.toString());
     assert.done();
 };
+
+module.exports.namespace = function(assert) {
+    var str = '<?xml version="1.0" encoding="UTF-8"?>\n'+
+            '<root xmlns:bacon="http://www.example.com/fake/uri"><node bacon:attr-with-ns="attr-with-ns-value" attr-without-ns="attr-withoug-ns-vavlue" /></root>';
+    var doc = new libxml.parseXml(str);
+    var node = doc.get('node');
+    var attrs = node.attrs();
+
+    attrs.forEach(function(attr) {
+        var name = attr.name();
+        var ns = attr.namespace();
+
+        if (name === 'attr-with-ns') {
+            assert.equal(ns.prefix(), 'bacon');
+            assert.equal(ns.href(), 'http://www.example.com/fake/uri');
+        } else {
+            assert.equal(name, 'attr-without-ns');
+            assert.equal(ns, null);
+        }
+    });
+    assert.done();
+};


### PR DESCRIPTION
Libxml has a few functions that accept callbacks. One of those functions is [xmlDeregisterNodeDefault](http://www.xmlsoft.org/html/libxml-globals.html#xmlDeregisterNodeDefault). This function sets the default callback function that is called when any node is "deregistered" (i.e. before freeing). The callback is also called for all of the node's children.

We can use this function to prevent bad access related segmentation faults by setting a flag saying that the xmlNode has already been freed. The XmlNode destructor code will then check the flag and return if it has already been freed.

#### In `libxmljs.cc`:
```cpp

// set up our callback function that will set the flag

void flagNode(xmlNode* node) {
  if (node->_private) {
    (static_cast<XmlNode*>(node->_private))->isFree = true;
  }
  return;
}

// set the callback function to be called

LibXMLJS::LibXMLJS()
{
    xmlDeregisterNodeDefault(flagNode);

....

}
```

#### In `xml_node.h`:

```cpp
class XmlNode : public node::ObjectWrap {
public:
    bool isFree;
```

#### In `xml_node.cc`:
```cpp
// The constructor will set the default value to false

XmlNode::XmlNode(xmlNode* node) : xml_obj(node) {
    this->isFree = false;

...
}


// The destructor will check the value

XmlNode::~XmlNode() {
    if (this->isFree) {
      return;
    }

...
}
```

Now every time an xmlNode (or any of its children) is freed, the callback will set a flag on the libxmljs Node object saying that the xmlNode has already been freed. Since the destructor will have this information it will not attempt to free the node or access properties of the node causing a segfault. This solution works without any additional ref counting code or memory leaks.