### PR TITLE
Segfault prevention/safety

### DIFF
--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -97,8 +97,26 @@ char* xmlMemoryStrdupWrap(const char* str)
     return res;
 }
 
+// callback function for `xmlDeregisterNodeDefault`
+void xmlDeregisterNodeCallback(xmlNode* xml_obj)
+{
+    if (xml_obj->_private)
+    {
+        XmlNode* node = static_cast<XmlNode*>(xml_obj->_private);
+
+        // flag the XmlNode object as freed
+        node->freed = true;
+
+        // save a reference to the doc so we can still `unref` it
+        node->doc = xml_obj->doc;
+    }
+    return;
+}
+
 LibXMLJS::LibXMLJS()
 {
+    // set the callback for when a node is about to be freed
+    xmlDeregisterNodeDefault(xmlDeregisterNodeCallback);
 
     // populated debugMemSize (see xmlmemory.h/c) and makes the call to
     // xmlMemUsed work, this must happen first!

--- a/src/xml_node.h
+++ b/src/xml_node.h
@@ -12,6 +12,12 @@ public:
 
     xmlNode* xml_obj;
 
+    // boolean value to check if `xml_obj` was already freed
+    bool freed;
+
+    // backup reference to the doc in case `xml_obj` was already freed
+    xmlDoc* doc;
+
     explicit XmlNode(xmlNode* node);
     virtual ~XmlNode();
 

--- a/test/ref_integrity.js
+++ b/test/ref_integrity.js
@@ -25,3 +25,26 @@ module.exports.references = function(assert) {
     assert.equal("child", nodes[1].name());
     assert.done();
 };
+
+// test that double-freeing XmlNode's doesn't cause a segfault
+module.exports.double_free = function(assert) {
+    var children = null;
+
+    // stick this portion of code into a self-executing function so
+    // its internal variables can be garbage collected
+    (function(){
+        var html = '<html><body><div><span></span></div></body></html>';
+        var doc = libxml.parseHtml(html);
+
+        doc.find('//div').forEach(function(tag){
+            // provide a reference to childNodes so they are exposed as XmlNodes
+            // and therefore subject to V8's garbage collection
+            children = tag.childNodes();
+            tag.remove();
+        });
+    })();
+
+    global.gc();
+    assert.ok( children[0].attrs() );
+    assert.done();
+};


### PR DESCRIPTION
This pull request causes XmlNodes to Ref() their parents. This causes the parent node's ref count to increase, which means that it won't be GC'ed until the ref count goes back down to 0. When the child node's destructor is called, it Unref()'s the parent node which decreases the parent ref count. This forces parent nodes to stick around while there are still children that haven't been freed.

This pull request also causes libxmljs to check that `xml_obj` hasn't been freed before it tries to access any of its properties. This mitigates segfaults caused by the XmlNode destructor accessing `xml_obj` properties. Though the parent Ref() part of this pull request already fixes most known segfault issues, this is still useful as an extra safety check to provide protection against undiscovered segfaults.

This pull request passes all tests, including the `double_free` test, without any known issues or memory leaks.

*Note:* Both of these features are almost identical to the memory management steps Ruby has taken in [libxml-ruby](https://github.com/xml4r/libxml-ruby/blob/master/ext/libxml/ruby_xml_node.c).