### PR TITLE
HTML toString() support

### DIFF
--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -5,6 +5,8 @@
 
 #include <cstring>
 
+//#include <libxml/tree.h>
+#include <libxml/HTMLtree.h>
 #include <libxml/HTMLparser.h>
 #include <libxml/xmlschemas.h>
 #include <libxml/relaxng.h>
@@ -174,7 +176,11 @@ NAN_METHOD(XmlDocument::ToString)
 
     xmlChar* buffer = NULL;
     int len = 0;
-    xmlDocDumpFormatMemoryEnc(document->xml_obj, &buffer, &len, "UTF-8", args[0]->BooleanValue() ? 1 : 0);
+    if (document->xml_obj->type == XML_HTML_DOCUMENT_NODE) {
+        htmlDocDumpMemoryFormat(document->xml_obj, &buffer, &len, args[0]->BooleanValue() ? 1 : 0);
+    }else{
+        xmlDocDumpFormatMemoryEnc(document->xml_obj, &buffer, &len, "UTF-8", args[0]->BooleanValue() ? 1 : 0);
+    }
     v8::Local<v8::String> str = NanNew<v8::String>((const char*)buffer, len);
     xmlFree(buffer);
 

--- a/src/xml_node.h
+++ b/src/xml_node.h
@@ -53,7 +53,7 @@ protected:
     v8::Local<v8::Value> get_line_number();
     v8::Local<v8::Value> clone(bool recurse);
     v8::Local<v8::Value> get_type();
-    v8::Local<v8::Value> to_string();
+    v8::Local<v8::Value> to_string(int options = 0);
     void remove();
 };
 

--- a/test/element.js
+++ b/test/element.js
@@ -62,6 +62,10 @@ module.exports.toString = function(assert) {
     assert.equal('<name1/>', elem.toString());
     elem.node('child');
     assert.equal('<name1><child/></name1>', elem.toString());
+    assert.equal('<name1><child></child></name1>', elem.toString({ selfCloseEmpty: false }));
+    assert.equal('<name1><child></child></name1>', elem.toString({ type: 'html' }));
+    assert.equal('<name1\n  ><child\n  /></name1\n>', elem.toString({ whitespace: true }));
+    assert.equal('<name1>\n  <child/>\n</name1>', elem.toString({ format: true }));
     assert.done();
 };
 


### PR DESCRIPTION
This pull request causes Document.toString() to check whether the document is HTML or XML and serializes it accordingly. Also, Node.toString() now accepts a boolean argument for formatting the output. Since Document.toString has formatting turned on by default, Node.toString also formats the output by default.

Support for the rest of the xmlSaveOptions can be easily added. Maybe in a future release `toString` will also support an object argument like this:

```javascript
toString({
    format: true,       // formatting
    declaration: false,	// xml declaration
    emptyTags: true,    // include empty tags
    type: 'HTML'        // force output type
    xhtml: true,        // follow XHTML1 specific rules
})
```