### PR TITLE
Fix memory leaks and segfaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,3 +34,5 @@ var sax_parser = require('./lib/sax_parser');
 module.exports.SaxParser = sax_parser.SaxParser;
 module.exports.SaxPushParser = sax_parser.SaxPushParser;
 
+module.exports.xmlMemUsed = bindings.xmlMemUsed;
+

--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -148,12 +148,8 @@ void xmlDeregisterNodeCallback(xmlNode* xml_obj)
     if (xml_obj->_private)
     {
         XmlNode* node = static_cast<XmlNode*>(xml_obj->_private);
-
-        // flag the XmlNode object as freed
-        node->freed = true;
-
-        // save a reference to the doc so we can still `unref` it
-        node->doc = xml_obj->doc;
+        node->xml_obj = NULL;
+        xml_obj->_private = NULL;
     }
     return;
 }

--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -222,6 +222,12 @@ v8::Local<v8::Object> listFeatures() {
     return scope.Escape(target);
 }
 
+NAN_METHOD(XmlMemUsed)
+{
+  Nan::HandleScope scope;
+  return info.GetReturnValue().Set(Nan::New<v8::Int32>(xmlMemUsed()));
+}
+
 NAN_MODULE_INIT(init)
 {
       Nan::HandleScope scope;
@@ -241,6 +247,8 @@ NAN_MODULE_INIT(init)
       Nan::Set(target, Nan::New<v8::String>("features").ToLocalChecked(), listFeatures());
 
       Nan::Set(target, Nan::New<v8::String>("libxml").ToLocalChecked(), target);
+
+      Nan::SetMethod(target, "xmlMemUsed", XmlMemUsed);
 }
 
 NODE_MODULE(xmljs, init)

--- a/src/xml_node.cc
+++ b/src/xml_node.cc
@@ -229,64 +229,243 @@ XmlNode::New(xmlNode* node)
 }
 
 XmlNode::XmlNode(xmlNode* node) : xml_obj(node) {
-    this->freed = false;
     xml_obj->_private = this;
 
     // this will prevent the document from being cleaned up
     // we keep the document if any of the nodes attached to it are still alive
-    XmlDocument* doc = static_cast<XmlDocument*>(xml_obj->doc->_private);
+    this->doc = xml_obj->doc;
+    XmlDocument* doc = static_cast<XmlDocument*>(this->doc->_private);
     doc->ref();
+}
 
-    // check that there's a parent node with a _private pointer
-    // also check that the parent node isn't the doc since we already Ref() the doc once
-    if (xml_obj->parent != NULL &&
-        xml_obj->parent->_private != NULL &&
-        (void*)xml_obj->doc != (void*)xml_obj->parent)
-    {
-        static_cast<XmlNode*>(xml_obj->parent->_private)->Ref();
+/*
+ * Return the (non-document) root, or a proxied ancestor: whichever is closest
+ */
+xmlNode*
+findProxiedAncestorOrRoot(xmlNode *xml_obj) {
+    while ((xml_obj->parent != NULL) &&
+           (static_cast<void*>(xml_obj->doc) != static_cast<void*>(xml_obj->parent))  &&
+           (xml_obj->parent->_private == NULL)) {
+        xml_obj = xml_obj->parent;
     }
+    return ((xml_obj->parent != NULL) &&
+            (static_cast<void*>(xml_obj->doc) != static_cast<void*>(xml_obj->parent))) ?
+        xml_obj->parent : xml_obj;
+}
+
+
+/*
+ * Search linked list for javascript proxy, ignoring given node.
+ */
+xmlAttr*
+findProxiedAttrInList(xmlAttr *xml_obj, void *skip_xml_obj) {
+    xmlAttr *proxied_attr = NULL;
+    while (xml_obj != NULL) {
+        if ((xml_obj != skip_xml_obj) && (xml_obj->_private != NULL)) {
+            proxied_attr = xml_obj;
+            xml_obj = NULL;
+        }
+        else {
+            xml_obj = xml_obj->next;
+        }
+    }
+    return proxied_attr;
+}
+
+xmlNs*
+findProxiedNsInList(xmlNs *xml_obj, void *skip_xml_obj) {
+    xmlNs *proxied_ns = NULL;
+    while (xml_obj != NULL) {
+        if ((xml_obj != skip_xml_obj) && (xml_obj->_private != NULL)) {
+            proxied_ns = xml_obj;
+            xml_obj = NULL;
+        }
+        else {
+            xml_obj = xml_obj->next;
+        }
+    }
+    return proxied_ns;
+}
+
+xmlNode* findProxiedNodeInChildren(xmlNode *xml_obj, void *skip_xml_obj);
+
+/*
+ * Search document for javascript proxy, ignoring given node.
+ * Based on xmlFreeDoc.
+ */
+xmlNode*
+findProxiedNodeInDocument(xmlDoc *xml_obj, void *skip_xml_obj) {
+    xmlNode *proxied_node = NULL;
+    if ((xml_obj->extSubset != NULL) &&
+        (xml_obj->extSubset->_private != NULL) &&
+        (static_cast<void*>(xml_obj->extSubset) != skip_xml_obj)) {
+        proxied_node = reinterpret_cast<xmlNode*>(xml_obj->extSubset);
+    }
+    if ((proxied_node == NULL) &&
+        (xml_obj->intSubset != NULL) &&
+        (xml_obj->intSubset->_private != NULL) &&
+        (static_cast<void*>(xml_obj->intSubset) != skip_xml_obj)) {
+        proxied_node = reinterpret_cast<xmlNode*>(xml_obj->intSubset);
+    }
+    if ((proxied_node == NULL) && (xml_obj->children != NULL)) {
+        proxied_node =
+            findProxiedNodeInChildren(xml_obj->children, skip_xml_obj);
+    }
+    if ((proxied_node == NULL) && (xml_obj->oldNs != NULL)) {
+        proxied_node =
+            reinterpret_cast<xmlNode*>(findProxiedNsInList(xml_obj->oldNs, skip_xml_obj));
+
+    }
+    return proxied_node;
+}
+
+/*
+ * Search children of node for javascript proxy, ignoring given node.
+ * Based on xmlFreeNodeList.
+ */
+xmlNode*
+findProxiedNodeInChildren(xmlNode *xml_obj, xmlNode *skip_xml_obj) {
+
+    xmlNode* proxied_node = NULL;
+
+    if (xml_obj->type == XML_NAMESPACE_DECL) {
+        return reinterpret_cast<xmlNode*>(
+            findProxiedNsInList(reinterpret_cast<xmlNs*>(xml_obj), skip_xml_obj)
+        );
+    }
+
+    if ((xml_obj->type == XML_DOCUMENT_NODE) ||
+#ifdef LIBXML_DOCB_ENABLED
+        (xml_obj->type == XML_DOCB_DOCUMENT_NODE) ||
+#endif
+        (xml_obj->type == XML_HTML_DOCUMENT_NODE)) {
+        return findProxiedNodeInDocument(reinterpret_cast<xmlDoc*>(xml_obj), skip_xml_obj);
+    }
+
+    xmlNode *next;
+    while (xml_obj != NULL) {
+        next = xml_obj->next;
+
+        if ((xml_obj != skip_xml_obj) && (xml_obj->_private != NULL)) {
+            proxied_node = xml_obj;
+        }
+        else {
+
+            if ((xml_obj->children != NULL) && (xml_obj->type != XML_ENTITY_REF_NODE)) {
+                proxied_node = findProxiedNodeInChildren(xml_obj->children, skip_xml_obj);
+            }
+
+            if ((proxied_node == NULL) &&
+                ((xml_obj->type == XML_ELEMENT_NODE) ||
+                 (xml_obj->type == XML_XINCLUDE_START) ||
+                 (xml_obj->type == XML_XINCLUDE_END))) {
+
+                if ((proxied_node == NULL) && (xml_obj->properties != NULL)) {
+                    proxied_node =
+                        reinterpret_cast<xmlNode*>(findProxiedAttrInList(xml_obj->properties, skip_xml_obj));
+                }
+
+                if ((proxied_node == NULL) && (xml_obj->nsDef != NULL)) {
+                    proxied_node =
+                        reinterpret_cast<xmlNode*>(findProxiedNsInList(xml_obj->nsDef, skip_xml_obj));
+                }
+            }
+
+        }
+
+        if (proxied_node != NULL) {
+            break;
+        }
+
+        xml_obj = next;
+    }
+
+    return proxied_node;
+}
+
+/*
+ * Search descendants of node to find javascript proxy,
+ * optionally ignoring given node. Based on xmlFreeNode.
+ */
+xmlNode*
+findProxiedDescendant(xmlNode *xml_obj, xmlNode *skip_xml_obj=NULL) {
+
+    xmlNode* proxied_descendant = NULL;
+
+    if (xml_obj->type == XML_DTD_NODE) {
+        return (xml_obj->children == NULL) ?
+            NULL : findProxiedNodeInChildren(xml_obj->children, skip_xml_obj);
+    }
+
+    if (xml_obj->type == XML_NAMESPACE_DECL) {
+        return NULL;
+    }
+
+    if (xml_obj->type == XML_ATTRIBUTE_NODE) {
+        return (xml_obj->children == NULL) ?
+            NULL : findProxiedNodeInChildren(xml_obj->children, skip_xml_obj);
+    }
+
+    if ((xml_obj->children != NULL) && (xml_obj->type != XML_ENTITY_REF_NODE)) {
+        proxied_descendant =
+            findProxiedNodeInChildren(xml_obj->children, skip_xml_obj);
+    }
+
+    if ((xml_obj->type == XML_ELEMENT_NODE) ||
+        (xml_obj->type == XML_XINCLUDE_START) ||
+        (xml_obj->type == XML_XINCLUDE_END)) {
+
+        if ((proxied_descendant == NULL) && (xml_obj->properties != NULL)) {
+            proxied_descendant =
+                reinterpret_cast<xmlNode*>(findProxiedAttrInList(xml_obj->properties, skip_xml_obj));
+        }
+
+        if ((proxied_descendant == NULL) && (xml_obj->nsDef != NULL)) {
+            proxied_descendant =
+                reinterpret_cast<xmlNode*>(findProxiedNsInList(xml_obj->nsDef, skip_xml_obj));
+        }
+    }
+
+    return proxied_descendant;
 }
 
 XmlNode::~XmlNode() {
 
     // check if `xml_obj` has been freed so we don't access bad memory
-    if (this->freed)
+    if (!this->xml_obj)
     {
 
-        // unref the doc using the doc reference we saved in the `flagNode` callback
-        if (this->doc)
+        // unref the doc
+        if ((this->doc) && (this->doc->_private != NULL))
         {
             XmlDocument* doc = static_cast<XmlDocument*>(this->doc->_private);
             doc->unref();
+            this->doc = NULL;
         }
-
-        // set doc to null for good measure?
-        // this->doc = NULL;
 
         // return so we don't attempt to use `xml_obj`
         return;
     }
 
     xml_obj->_private = NULL;
-    // release the hold and allow the document to be freed
-    XmlDocument* doc = static_cast<XmlDocument*>(xml_obj->doc->_private);
-    doc->unref();
 
-    // We do not free the xmlNode here if it is linked to a document
-    // It will be freed when the doc is freed
-    if (xml_obj->parent == NULL)
-      xmlFreeNode(xml_obj);
+    if ((this->doc) && (this->doc->_private != NULL)) {
+        XmlDocument* doc = static_cast<XmlDocument*>(xml_obj->doc->_private);
+        doc->unref();
+        this->doc = NULL;
+    }
 
-    // if there's a parent then Unref() it
-    else if (xml_obj->parent->_private != NULL &&
-            (void*)xml_obj->doc != (void*)xml_obj->parent)
-    {
-        XmlNode* parent = static_cast<XmlNode*>(xml_obj->parent->_private);
-
-        // make sure Unref() is necessary
-        if (parent->refs_ > 0)
-        {
-            parent->Unref();
+    if (xml_obj->parent == NULL) {
+        if (findProxiedDescendant(xml_obj) == NULL) {
+            xmlFreeNode(xml_obj);
+        }
+    }
+    else {
+        xmlNode *ancestor = findProxiedAncestorOrRoot(xml_obj);
+        if ((ancestor->_private == NULL) &&
+            (ancestor->parent == NULL) &&
+            (findProxiedDescendant(ancestor, xml_obj) == NULL)) {
+            xmlFreeNode(ancestor);
         }
     }
 }

--- a/src/xml_node.h
+++ b/src/xml_node.h
@@ -12,10 +12,7 @@ public:
 
     xmlNode* xml_obj;
 
-    // boolean value to check if `xml_obj` was already freed
-    bool freed;
-
-    // backup reference to the doc in case `xml_obj` was already freed
+    // the doc ref'd by this proxy
     xmlDoc* doc;
 
     explicit XmlNode(xmlNode* node);

--- a/test/document.js
+++ b/test/document.js
@@ -331,16 +331,11 @@ module.exports.validate_memory_usage = function(assert) {
     var xsdDoc = libxml.parseXml(xsd);
     var xmlDoc = libxml.parseXml(xml);
 
-    var initialMemory = process.memoryUsage();
-
+    var rssBefore = rssAfterGarbageCollection();
     for (var i = 0; i < 10000; ++i) {
         xmlDoc.validate(xsdDoc);
     }
-
-    global.gc();
-
-    var maxRssDelta = /^v0\.8/.test(process.version) ? (initialMemory.rss / 2) : 2000000;
-    assert.ok(process.memoryUsage().rss - initialMemory.rss < maxRssDelta);
+    assert.ok((rssAfterGarbageCollection() - rssBefore) < VALIDATE_RSS_TOLERANCE);
     assert.done();
 };
 
@@ -374,16 +369,32 @@ module.exports.validate_rng_memory_usage = function(assert) {
     var rngDoc = libxml.parseXml(rng);
     var xmlDoc = libxml.parseXml(xml_valid);
 
-    var initialMemory = process.memoryUsage();
-
+    var rssBefore = rssAfterGarbageCollection();
     for (var i = 0; i < 10000; ++i) {
         xmlDoc.rngValidate(rngDoc);
     }
-
-    global.gc();
-
-    var maxRssDelta = /^v0\.8/.test(process.version) ? (initialMemory.rss / 2) : 2000000;
-    assert.ok(process.memoryUsage().rss - initialMemory.rss < maxRssDelta);
+    assert.ok((rssAfterGarbageCollection() - rssBefore) < VALIDATE_RSS_TOLERANCE);
     assert.done();
 };
+
+var VALIDATE_RSS_TOLERANCE = 100000;
+
+function rssAfterGarbageCollection(maxCycles) {
+    maxCycles || (maxCycles = 10);
+
+    var rss = process.memoryUsage().rss;
+    var freedMemory = 0;
+    do {
+        global.gc();
+
+        var rssAfterGc = process.memoryUsage().rss;
+        freedMemory = rss - rssAfterGc;
+        rss = rssAfterGc;
+
+        maxCycles--;
+    }
+    while ((freedMemory !== 0) && (maxCycles > 0));
+
+    return rss;
+}
 

--- a/test/main.js
+++ b/test/main.js
@@ -10,3 +10,8 @@ module.exports.constants = function(assert) {
     assert.done();
 };
 
+module.exports.xmlMemUsed = function(assert) {
+    assert.ok(typeof libxml.xmlMemUsed() === 'number');
+    assert.done();
+};
+

--- a/test/memory_management.js
+++ b/test/memory_management.js
@@ -1,0 +1,81 @@
+var libxml = require('../index');
+
+if (!global.gc) {
+    throw new Error('must run with --expose_gc for memory management tests');
+}
+
+module.exports.setUp = function(done) {
+    collectGarbage();
+    done();
+};
+
+module.exports.inaccessible_document_freed = function(assert) {
+    var xml_memory_before_document = libxml.xmlMemUsed();
+    for (var i=0; i<10; i++) {
+      makeDocument();
+    }
+    collectGarbage();
+    assert.ok(libxml.xmlMemUsed() <= xml_memory_before_document);
+    assert.done();
+};
+
+module.exports.inaccessible_document_freed_when_node_freed = function(assert) {
+    var xml_memory_before_document = libxml.xmlMemUsed();
+    var nodes = [];
+    for (var i=0; i<10; i++) {
+      nodes.push(makeDocument().get('//center'));
+    }
+    nodes = null;
+    collectGarbage();
+    assert.ok(libxml.xmlMemUsed() <= xml_memory_before_document);
+    assert.done();
+};
+
+module.exports.inaccessible_document_freed_after_middle_nodes_proxied = function(assert) {
+    var xml_memory_before_document = libxml.xmlMemUsed();
+    var doc = makeDocument();
+    var middle = doc.get('//middle');
+    var inner = doc.get('//inner');
+    inner.remove(); // v0.14.3, v0.15: proxy ref'd parent but can't unref when destroyed
+    doc = middle = inner = null;
+    collectGarbage();
+    assert.ok(libxml.xmlMemUsed() <= xml_memory_before_document);
+    assert.done();
+};
+
+module.exports.inaccessible_tree_freed = function(assert) {
+    var doc = makeDocument();
+    var xml_memory_after_document = libxml.xmlMemUsed();
+    doc.get('//middle').remove();;
+    collectGarbage();
+    assert.ok(libxml.xmlMemUsed() < xml_memory_after_document);
+    assert.done();
+};
+
+function makeDocument() {
+    var body = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+        "<root><outer><middle><inner><center/></inner></middle></outer></root>";
+    return libxml.parseXml(body);
+}
+
+function collectGarbage(minCycles, maxCycles) {
+    minCycles = minCycles || 3;
+    maxCycles = maxCycles || 10;
+
+    var cycles = 0;
+    var freedRss = 0;
+    var usage = process.memoryUsage();
+    do {
+        global.gc();
+
+        var usageAfterGc = process.memoryUsage();
+        freedRss = usage.rss - usageAfterGc.rss;
+        usage = usageAfterGc;
+
+        cycles++;
+    }
+    while ((cycles < minCycles) || ((freedRss !== 0) && (cycles < maxCycles)));
+
+    return usage;
+}
+

--- a/test/ref_integrity.js
+++ b/test/ref_integrity.js
@@ -60,4 +60,97 @@ module.exports.freed_namespace_unwrappable = function(assert) {
     assert.done();
 };
 
+module.exports.unlinked_tree_persistence_parent_proxied_first = function(assert) {
+  var doc = makeDocument();
+  var parent_node = doc.get('//middle');
+  var child_node = doc.get('//inner');
+
+  parent_node.remove();
+  parent_node = null;
+  collectGarbage();
+
+  assert.equal("inner", child_node.name()); // works with >= v0.14.3
+  assert.done();
+};
+
+module.exports.unlinked_tree_persistence_child_proxied_first = function(assert) {
+  var doc = makeDocument();
+  var child_node = doc.get('//inner');
+  var parent_node = doc.get('//middle');
+
+  parent_node.remove();
+  parent_node = null;
+  collectGarbage();
+
+  assert.equal("inner", child_node.name()); // fails with v0.14.3, v0.15
+  assert.done();
+};
+
+module.exports.unlinked_tree_proxied_leaf_persistent = function(assert) {
+  var doc = makeDocument();
+  var ancestor = doc.get('//middle');
+  var leaf = doc.get('//center');
+
+  ancestor.remove();
+  ancestor = null;
+  collectGarbage();
+
+  assert.equal("center", leaf.name()); // fails with v0.14.3, v0.15
+  assert.done();
+};
+
+module.exports.unlinked_tree_leaf_persistence_with_proxied_ancestor = function(assert) {
+  var doc = makeDocument();
+  var proxied_ancestor = doc.get('//inner');
+  var leaf = doc.get('//center');
+
+  doc.get('//middle').remove();
+  leaf = null;
+  collectGarbage();
+
+  leaf = proxied_ancestor.get('.//center');
+  assert.equal("center", leaf.name());
+  assert.done();
+};
+
+module.exports.unlinked_tree_leaf_persistence_with_peer_proxy = function(assert) {
+  var doc = makeDocument();
+  var leaf = doc.get('//left');
+  var peer = doc.get('//right');
+
+  doc.get('//middle').remove();
+  leaf = null;
+  collectGarbage();
+
+  leaf = peer.parent().get('./left');
+  assert.equal("left", leaf.name());
+  assert.done();
+};
+
+function makeDocument() {
+    var body = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+        "<root><outer><middle><inner><left/><center/><right/></inner></middle></outer></root>";
+    return libxml.parseXml(body);
+}
+
+function collectGarbage(minCycles, maxCycles) {
+    minCycles = minCycles || 3;
+    maxCycles = maxCycles || 10;
+
+    var cycles = 0;
+    var freedRss = 0;
+    var usage = process.memoryUsage();
+    do {
+        global.gc();
+
+        var usageAfterGc = process.memoryUsage();
+        freedRss = usage.rss - usageAfterGc.rss;
+        usage = usageAfterGc;
+
+        cycles++;
+    }
+    while ((cycles < minCycles) || ((freedRss !== 0) && (cycles < maxCycles)));
+
+    return usage;
+}
 


### PR DESCRIPTION
Upgraded to v0.15 from v0.13, but then had to revert due to leaking memory. I think the root cause may be in #323 (43310754): Node wrappers ref() their parents, but don't unref() them in the case that they are unlinked from the parents. This could immortalize the parents, which in turn hold refs on the documents.

The fix (not ref'ing or unref'ing parents) is in e5996f4b, along with an alternate solution to the underlying problem: Not freeing a detached tree while it is still reachable from javascript. #323 accomplished this by preventing the root wrapper from being destroyed, but it only worked in the case that the detached root and an immediate child were wrapped, and in that precise order, such as in the "double_free" test in the ref_integrity test suite. The proposed solution allows an unreachable wrapper to be destroyed, but it only frees the wrapped node tree if no connected nodes are wrapped/reachable.

The cost of this solution — searching for reachable nodes whenever a wrapper is destroyed — is worth reconsidering. I made a couple optimizations:

1. If any of a wrapper's ancestors nodes are wrapped, the search is aborted. Such a node is reachable, so the tree cannot be freed.
2. If a wrapper's node is the document root, or is connected to the document root, the search is aborted, since the tree is reachable as long as the document is.

Further optimizations may be possible. Another approach would be to for the nodes of detached trees to maintain references to their root nodes.

Also included in this PR is ~~a fix for a memory leak when performing RelaxNG validation, explicit handles scopes (though I haven't seen any clear indication that leaking handles are a problem), and~~ exposing xmlMemUsed so that it can be used in tests to verify memory management.

v0.14.3 - v0.15 fail the "inaccessible_document_freed_after_middle_nodes_proxied" test (verifying the memory leak which prompted this PR) and all tests in the "referential_integrity" suite after "unlinked_tree_persistence_parent_proxied_first". 