### PR TITLE
Comment nodes should not escape xml characters

### DIFF
--- a/src/xml_comment.cc
+++ b/src/xml_comment.cc
@@ -19,8 +19,7 @@ NAN_METHOD(XmlComment::New) {
 
   // if we were created for an existing xml node, then we don't need
   // to create a new node on the document
-  if (info.Length() == 0)
-  {
+  if (info.Length() == 0) {
       return info.GetReturnValue().Set(info.Holder());
   }
 
@@ -28,17 +27,13 @@ NAN_METHOD(XmlComment::New) {
   assert(document);
 
   v8::Local<v8::Value> contentOpt;
-  if(info[1]->IsString()) {
+  if (info[1]->IsString()) {
       contentOpt = info[1];
   }
   v8::String::Utf8Value contentRaw(contentOpt);
   const char* content = (contentRaw.length()) ? *contentRaw : NULL;
 
-  xmlChar* encoded = content ? xmlEncodeSpecialChars(document->xml_obj, (const xmlChar*)content) : NULL;
-  xmlNode* comm = xmlNewDocComment(document->xml_obj,
-                                   encoded);
-  if (encoded)
-      xmlFree(encoded);
+  xmlNode* comm = xmlNewDocComment(document->xml_obj, (xmlChar *) content);
 
   XmlComment* comment = new XmlComment(comm);
   comm->_private = comment;
@@ -66,9 +61,7 @@ NAN_METHOD(XmlComment::Text) {
 
 void
 XmlComment::set_content(const char* content) {
-  xmlChar *encoded = xmlEncodeSpecialChars(xml_obj->doc, (const xmlChar*)content);
-  xmlNodeSetContent(xml_obj, encoded);
-  xmlFree(encoded);
+  xmlNodeSetContent(xml_obj, (xmlChar*) content);
 }
 
 v8::Local<v8::Value>
@@ -84,7 +77,6 @@ XmlComment::get_content() {
 
   return scope.Escape(Nan::New<v8::String>("").ToLocalChecked());
 }
-
 
 v8::Local<v8::Object>
 XmlComment::New(xmlNode* node)

--- a/test/comment.js
+++ b/test/comment.js
@@ -16,3 +16,21 @@ module.exports.text = function(assert) {
     assert.done();
 };
 
+
+module.exports.textWithSpecialCharacters = function(assert) {
+    var doc = libxml.Document();
+    var comm = libxml.Comment(doc);
+    var theText = 'my comment <has> special ch&r&cters';
+    comm.text(theText);
+    assert.equal(theText, comm.text());
+    assert.done();
+};
+
+module.exports.toStringWithSpecialCharacters = function(assert) {
+    var doc = libxml.Document();
+    var comm = libxml.Comment(doc);
+    var theText = 'my comment <has> special ch&r&cters';
+    comm.text(theText);
+    assert.equal("<!--" + theText + "-->", comm.toString());
+    assert.done();
+};


### PR DESCRIPTION
We want to allow the creation of comments that you would expect to see for IE conditionals in HTML markup. For example:

```html
<!--[if IE 6]>
Special instructions for IE 6 here
<![endif]-->
```

Should not escape the inner text of the comment. I can't think of a reason where escaping comment text *should* be necessary.