### PR TITLE
Document.fromHtmlFragment

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports.parseXml = Document.fromXml;
 
 /// parse an html string and return a Document
 module.exports.parseHtml = Document.fromHtml;
+module.exports.parseHtmlFragment = Document.fromHtmlFragment;
 
 // constants
 module.exports.version = require('./package.json').version;
@@ -26,7 +27,7 @@ module.exports.Comment = require('./lib/comment');
 
 // Compatibility synonyms
 Document.fromXmlString = Document.fromXml;
-Document.fromHtmlString = Document.fromHtmlString;
+Document.fromHtmlString = Document.fromHtml;
 module.exports.parseXmlString = module.exports.parseXml;
 module.exports.parseHtmlString = module.exports.parseHtml;
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -143,6 +143,23 @@ module.exports.fromHtml = function(string, opts) {
     return bindings.fromHtml(string, opts);
 };
 
+/// parse a string into a html document fragment
+/// @param string html string to parse
+/// @param {encoding:string, baseUrl:string} opts html string to parse
+/// @return a Document
+module.exports.fromHtmlFragment = function(string, opts) {
+    opts = opts || {};
+
+    // if for some reason user did not specify an object for the options
+    if (typeof(opts) !== 'object') {
+        throw new Error('fromHtmlFragment options must be an object');
+    }
+
+    opts.excludeImpliedElements = true;
+
+    return bindings.fromHtml(string, opts);
+};
+
 /// parse a string into a xml document
 /// @param string xml string to parse
 /// @return a Document

--- a/src/xml_document.h
+++ b/src/xml_document.h
@@ -53,7 +53,12 @@ protected:
     static NAN_METHOD(Errors);
     static NAN_METHOD(ToString);
     static NAN_METHOD(Validate);
-    static NAN_METHOD(RngValidate);	
+    static NAN_METHOD(RngValidate);
+
+
+    // Static member variables
+    static const int DEFAULT_PARSING_OPTS;
+    static const int EXCLUDE_IMPLIED_ELEMENTS;
 };
 
 }  // namespace libxmljs

--- a/test/document.js
+++ b/test/document.js
@@ -344,6 +344,24 @@ module.exports.validate_memory_usage = function(assert) {
     assert.done();
 };
 
+module.exports.fromHtml = function(assert) {
+    var html = "<p>A paragraph with <span>inline tags</span></p>";
+    var header = '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">\n<html><body>';
+    var footer = "</body></html>\n";
+    var parsedHtml = libxml.Document.fromHtml(html);
+    assert.equal(header + html + footer, parsedHtml.toString());
+    assert.done();
+};
+
+module.exports.fromHtmlFragment = function(assert) {
+    var html = "<p>A paragraph with <span>inline tags</span></p>";
+    var parsedHtml = libxml.Document.fromHtmlFragment(html);
+
+    assert.equal(html + "\n", parsedHtml.toString());
+    assert.done();
+
+};
+
 module.exports.validate_rng_memory_usage = function(assert) {
   var rng =
     '<element name="addressBook" xmlns="http://relaxng.org/ns/structure/1.0">'+


### PR DESCRIPTION
This PR helps alleviate the issue of wanting to parse HTML fragments without them being wrapped in implied document elements (doctype, head, body, etc)