### PR TITLE
Prevent segfault when freeing namespace wrapper

### DIFF
--- a/src/xml_namespace.cc
+++ b/src/xml_namespace.cc
@@ -65,28 +65,49 @@ XmlNamespace::XmlNamespace(xmlNs* node) : xml_obj(node)
 {
     xml_obj->_private = this;
 
-    if (xml_obj->context)
+    /*
+     * If a context is present and wrapped, increment its refcount to ensure
+     * that it is considered accessible from javascript for as long as the
+     * namespace is accessible.
+     */
+    if ((xml_obj->context) && (xml_obj->context->_private != NULL))
     {
+        this->context = xml_obj->context;
         // a namespace must be created on a given node
         XmlDocument* doc = static_cast<XmlDocument*>(xml_obj->context->_private);
         doc->ref();
+    }
+    else {
+        this->context = NULL;
     }
 }
 
 XmlNamespace::~XmlNamespace()
 {
-    xml_obj->_private = NULL;
+    /*
+     * `xml_obj` may have been nulled by `xmlDeregisterNodeCallback` when
+     * the `xmlNs` was freed along with an attached node or document.
+     */
+    if (xml_obj != NULL) {
+        xml_obj->_private = NULL;
+    }
 
-    if (xml_obj->context)
+    /*
+     * The context pointer is only set if this wrapper has incremented the
+     * refcount of the context wrapper.
+     */
+    if (this->context != NULL)
     {
-        // release the hold and allow the document to be freed
-        XmlDocument* doc = static_cast<XmlDocument*>(xml_obj->context->_private);
-        doc->unref();
+        if (this->context->_private != NULL) {
+            // release the hold and allow the document to be freed
+            XmlDocument* doc = static_cast<XmlDocument*>(this->context->_private);
+            doc->unref();
+        }
+        this->context = NULL;
     }
 
     // We do not free the xmlNode here. It could still be part of a document
     // It will be freed when the doc is freed
-    // xmlFree(xml_obj);
 }
 
 NAN_METHOD(XmlNamespace::Href) {

--- a/src/xml_namespace.h
+++ b/src/xml_namespace.h
@@ -14,6 +14,8 @@ public:
 
     xmlNs* xml_obj;
 
+    xmlDoc* context; // reference-managed context
+
     static void Initialize(v8::Handle<v8::Object> target);
     static Nan::Persistent<v8::FunctionTemplate> constructor_template;
 

--- a/test/ref_integrity.js
+++ b/test/ref_integrity.js
@@ -48,3 +48,16 @@ module.exports.double_free = function(assert) {
     assert.ok( children[0].attrs() );
     assert.done();
 };
+
+module.exports.freed_namespace_unwrappable = function(assert) {
+    var doc = libxml.parseXml("<?xml version='1.0' encoding='UTF-8'?><root></root>");
+    var el = new libxml.Element(doc, "foo");
+    var ns = el.namespace("bar", null);
+    el = null;
+    global.gc();
+    ns = null;
+    global.gc();
+    assert.done();
+};
+
+


### PR DESCRIPTION
~XmlNamespace segfaults if the underlying xmlNs has been freed. Enhanced deregister node callback to prevent this from happening.