### PR TITLE
Fix text merge

### DIFF
--- a/src/xml_element.h
+++ b/src/xml_element.h
@@ -54,6 +54,9 @@ protected:
     v8::Local<v8::Value> get_prev_element();
     void replace_element(xmlNode* element);
     void replace_text(const char* content);
+    bool child_will_merge(xmlNode* child);
+    bool prev_sibling_will_merge(xmlNode* node);
+    bool next_sibling_will_merge(xmlNode* node);
 };
 
 }  // namespace libxmljs

--- a/src/xml_node.cc
+++ b/src/xml_node.cc
@@ -463,7 +463,7 @@ XmlNode::get_wrapped_ancestor() {
 
 void
 XmlNode::ref_wrapped_ancestor() {
-    xmlNode* ancestor = get_wrapped_ancestor();
+    xmlNode* ancestor = this->get_wrapped_ancestor();
 
     // if our closest wrapped ancestor has changed then we either
     // got removed, added, or a closer ancestor was wrapped
@@ -631,37 +631,27 @@ XmlNode::remove() {
 void
 XmlNode::add_child(xmlNode* child) {
   xmlAddChild(xml_obj, child);
-  // if the child is wrapped then we have to ref its parents
-  if (child->_private != NULL) {
-      XmlNode* node = static_cast<XmlNode*>(child->_private);
-      node->ref_wrapped_ancestor();
-  }
 }
 
 void
 XmlNode::add_prev_sibling(xmlNode* node) {
   xmlAddPrevSibling(xml_obj, node);
-  if (node->_private != NULL)
-    static_cast<XmlNode*>(node->_private)->ref_wrapped_ancestor();
 }
 
 void
 XmlNode::add_next_sibling(xmlNode* node) {
   xmlAddNextSibling(xml_obj, node);
-  if (node->_private != NULL)
-    static_cast<XmlNode*>(node->_private)->ref_wrapped_ancestor();
 }
 
 xmlNode*
-XmlNode::import_element(XmlNode *element) {
-  if (xml_obj->doc == element->xml_obj->doc) {
-      // remove the child from its parent
-      // (alternatively, we could clone and keep the original in place)
-      if (element->xml_obj->parent != NULL)
-        element->remove();
-      return element->xml_obj;
+XmlNode::import_node(xmlNode *node) {
+  if (xml_obj->doc == node->doc) {
+      if ((node->parent != NULL) && (node->_private != NULL)) {
+        static_cast<XmlNode*>(node->_private)->remove();
+      }
+      return node;
   }else{
-      return xmlDocCopyNode(element->xml_obj, xml_obj->doc, 1);
+      return xmlDocCopyNode(node, xml_obj->doc, 1);
   }
 }
 

--- a/src/xml_node.h
+++ b/src/xml_node.h
@@ -68,7 +68,7 @@ protected:
     void add_next_sibling(xmlNode* element);
     void replace_element(xmlNode* element);
     void replace_text(const char* content);
-    xmlNode *import_element(XmlNode* element);
+    xmlNode *import_node(xmlNode* node);
 };
 
 }  // namespace libxmljs

--- a/src/xml_text.h
+++ b/src/xml_text.h
@@ -36,9 +36,11 @@ protected:
     void set_content(const char* content);
     void replace_text(const char* content);
     void replace_element(xmlNode* element);
-    xmlNode *import_element(XmlText* element);
     void add_prev_sibling(xmlNode* element);
     void add_next_sibling(xmlNode* element);
+    bool prev_sibling_will_merge(xmlNode* node);
+    bool next_sibling_will_merge(xmlNode* node);
+
 };
 
 }  // namespace libxmljs

--- a/test/element.js
+++ b/test/element.js
@@ -205,4 +205,24 @@ module.exports.replace = function(assert) {
   assert.equal(doc.root().childNodes()[1].name(), 'enchanted');
 
   assert.done();
-}
+};
+
+module.exports.add_child_merge_text = function(assert) {
+  var str = "<foo>bar</foo>";
+  var doc = libxml.parseXml(str);
+  var foo = doc.root();
+  var baz = new libxml.Text(doc, "baz");
+  foo.addChild(baz);
+
+  // added text is merged into existing child node
+  assert.strictEqual("barbaz", foo.text());
+  assert.strictEqual(foo.childNodes().length, 1);
+  assert.ok(foo.childNodes()[0] != baz);
+
+  // passed node is not changed
+  assert.strictEqual(doc, baz.parent());
+  assert.strictEqual("baz", baz.text());
+
+  assert.done();
+};
+

--- a/test/text.js
+++ b/test/text.js
@@ -92,3 +92,44 @@ module.exports.addSiblings = function(assert) {
 
     assert.done();
 };
+
+module.exports.add_prev_sibling_merge_text = function(assert) {
+  var str = '<foo>bar<baz/></foo>';
+  var doc = libxml.parseXml(str);
+  var bar = doc.root().childNodes()[0];
+
+  var qux = new libxml.Text(doc, 'qux');
+  bar.addPrevSibling(qux);
+  // added text is merged into existing child node
+
+  var children = doc.root().childNodes();
+  assert.strictEqual(children.length, 2);
+  assert.strictEqual('quxbar', children[0].text());
+  assert.ok(children[0] != qux);
+
+  // passed node is not changed
+  assert.strictEqual(doc, qux.parent());
+  assert.strictEqual('qux', qux.text());
+
+  assert.done();
+};
+
+module.exports.add_next_sibling_merge_text = function(assert) {
+  var str = '<foo>bar<baz/></foo>';
+  var doc = libxml.parseXml(str);
+  var bar = doc.root().childNodes()[0];
+
+  var qux = new libxml.Text(doc, 'qux');
+  bar.addNextSibling(qux);
+
+  var children = doc.root().childNodes();
+  assert.strictEqual(children.length, 2);
+  assert.strictEqual('barqux', children[0].text());
+  assert.ok(children[0] != qux);
+
+  assert.strictEqual(doc, qux.parent());
+  assert.strictEqual('qux', qux.text());
+
+  assert.done();
+};
+


### PR DESCRIPTION
Extracted from PR #359. Memory fixes when adding merge-able text nodes (implemented in #351) as children or siblings. Includes implementation of XmlText add-sibling methods (already in header). Duplication can be reduced when XmlElement and XmlText (and XmlComment) are refactored to share a base class where methods inappropriate to XmlNode (which is shared by XmlAttribute) can be located.