### PR TITLE
.namespaces(local)

### DIFF
--- a/src/xml_node.cc
+++ b/src/xml_node.cc
@@ -89,7 +89,12 @@ NAN_METHOD(XmlNode::Namespaces) {
   XmlNode* node = Nan::ObjectWrap::Unwrap<XmlNode>(info.Holder());
   assert(node);
 
-  return info.GetReturnValue().Set(node->get_all_namespaces());
+  // ignore everything but a literal true; different from IsFalse
+  if ((info.Length() == 0) || !info[0]->IsTrue()) {
+      return info.GetReturnValue().Set(node->get_all_namespaces());
+  }
+
+  return info.GetReturnValue().Set(node->get_local_namespaces());
 }
 
 NAN_METHOD(XmlNode::Parent) {
@@ -349,6 +354,22 @@ XmlNode::get_all_namespaces() {
       Nan::Set(namespaces, index, ns);
     }
     xmlFree(nsList);
+  }
+
+  return scope.Escape(namespaces);
+}
+
+v8::Local<v8::Value>
+XmlNode::get_local_namespaces() {
+  Nan::EscapableHandleScope scope;
+
+  // Iterate through local namespaces
+  v8::Local<v8::Array> namespaces = Nan::New<v8::Array>();
+  xmlNs* nsDef = xml_obj->nsDef;
+  for(int i=0; nsDef; i++, nsDef = nsDef->next) {
+      v8::Local<v8::Number> index = Nan::New<v8::Number>(i);
+      v8::Local<v8::Object> ns = XmlNamespace::New(nsDef);
+      Nan::Set(namespaces, index, ns);
   }
 
   return scope.Escape(namespaces);

--- a/src/xml_node.h
+++ b/src/xml_node.h
@@ -47,6 +47,7 @@ protected:
     void set_namespace(xmlNs* ns);
     xmlNs * find_namespace(const char * search_str);
     v8::Local<v8::Value> get_all_namespaces();
+    v8::Local<v8::Value> get_local_namespaces();
     v8::Local<v8::Value> get_parent();
     v8::Local<v8::Value> get_prev_sibling();
     v8::Local<v8::Value> get_next_sibling();

--- a/test/namespace.js
+++ b/test/namespace.js
@@ -168,3 +168,43 @@ module.exports.custom_ns = function(assert) {
   assert.equal(div.toString(), exp.toString());
   assert.done();
 }
+
+module.exports.local_namespaces = function(assert) {
+  var str = '<html xmlns="urn:example" xmlns:ex1="urn:example:1"><body xmlns:ex2="urn:example:2"/></html>';
+  var doc = libxml.parseXmlString(str);
+  assert.ok(doc);
+  var root = doc.root();
+  assert.ok(root);
+  var decls = root.namespaces(true)
+  assert.ok(decls);
+  assert.equal(2, decls.length);
+  decls.forEach(function(n) {
+    if (n.prefix()==null) {
+      assert.equal("urn:example", n.href());
+    }
+    else if (n.prefix() == "ex1") {
+      assert.equal("urn:example:1", n.href());
+    }
+    else {
+      assert.ok(false);
+    }
+  });
+  // body has a namespace, from the default declaration on html.
+  var body = root.get('ex:body', {ex: 'urn:example'});
+  assert.ok(body);
+  decls = body.namespaces(true);
+  assert.equal(1, decls.length);
+  assert.equal("urn:example:2", decls[0].href())
+
+  // Make sure default behavior still works,
+  // and doesn't get turned on by mistake
+  decls = body.namespaces();
+  assert.equal(3, decls.length);
+  decls = body.namespaces(false);
+  assert.equal(3, decls.length);
+  decls = body.namespaces(0);
+  assert.equal(3, decls.length);
+  decls = body.namespaces(1);
+  assert.equal(3, decls.length);
+  assert.done();
+};


### PR DESCRIPTION
Fixes #270, replaces #271.

Replaces #271's `.nsDecls` API with `.namespaces(true)` (as suggested by @rc0x03 in https://github.com/polotek/libxmljs/pull/271#issuecomment-156881196), which only returns the namespaces that are locally defined on the target element.  Tested to ensure backward compatibility with existing code.

I will close #271, and refer to this PR.