### PR TITLE
Ref/Unref closest wrapped ancestor

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,3 +38,4 @@ module.exports.SaxPushParser = sax_parser.SaxPushParser;
 
 module.exports.memoryUsage = bindings.xmlMemUsed;
 
+module.exports.nodeCount = bindings.xmlNodeCount;

--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -88,6 +88,7 @@ NAN_METHOD(XmlDocument::Root)
     XmlElement* element = Nan::ObjectWrap::Unwrap<XmlElement>(info[0]->ToObject());
     assert(element);
     xmlDocSetRootElement(document->xml_obj, element->xml_obj);
+    element->ref_wrapped_ancestor();
     return info.GetReturnValue().Set(info[0]);
 }
 

--- a/src/xml_document.h
+++ b/src/xml_document.h
@@ -26,12 +26,13 @@ public:
     // given xmlDoc object, intended for use in c++ space
     static v8::Local<v8::Object> New(xmlDoc* doc);
 
-    void ref() {
-        Ref();
-    }
+    // publicly expose ref functions
+    using Nan::ObjectWrap::Ref;
+    using Nan::ObjectWrap::Unref;
 
-    void unref() {
-        Unref();
+    // expose ObjectWrap::refs_ (for testing)
+    int refs() {
+        return refs_;
     }
 
 protected:

--- a/src/xml_element.cc
+++ b/src/xml_element.cc
@@ -334,11 +334,6 @@ XmlElement::get_attrs() {
 }
 
 void
-XmlElement::add_child(xmlNode* child) {
-  xmlAddChild(xml_obj, child);
-}
-
-void
 XmlElement::add_cdata(xmlNode* cdata) {
   xmlAddChild(xml_obj, cdata);
 }
@@ -474,30 +469,18 @@ XmlElement::XmlElement(xmlNode* node)
 }
 
 void
-XmlElement::add_prev_sibling(xmlNode* element) {
-  xmlAddPrevSibling(xml_obj, element);
-}
-
-void
-XmlElement::add_next_sibling(xmlNode* element) {
-  xmlAddNextSibling(xml_obj, element);
-}
-
-void
 XmlElement::replace_element(xmlNode* element) {
   xmlReplaceNode(xml_obj, element);
+  if (element->_private != NULL) {
+      XmlNode* node = static_cast<XmlNode*>(element->_private);
+      node->ref_wrapped_ancestor();
+  }
 }
 
 void
 XmlElement::replace_text(const char* content) {
   xmlNodePtr txt = xmlNewDocText(xml_obj->doc, (const xmlChar*)content);
   xmlReplaceNode(xml_obj, txt);
-}
-
-xmlNode*
-XmlElement::import_element(XmlElement *element) {
-  return (xml_obj->doc == element->xml_obj->doc) ?
-        element->xml_obj : xmlDocCopyNode(element->xml_obj, xml_obj->doc, 1);
 }
 
 void

--- a/src/xml_element.h
+++ b/src/xml_element.h
@@ -47,17 +47,13 @@ protected:
     v8::Local<v8::Value> get_attr(const char* name);
     v8::Local<v8::Value> get_attrs();
     void set_attr(const char* name, const char* value);
-    void add_child(xmlNode* child);
     void add_cdata(xmlNode* cdata);
     void set_content(const char* content);
     v8::Local<v8::Value> get_content();
     v8::Local<v8::Value> get_next_element();
     v8::Local<v8::Value> get_prev_element();
-    void add_prev_sibling(xmlNode* element);
-    void add_next_sibling(xmlNode* element);
     void replace_element(xmlNode* element);
     void replace_text(const char* content);
-    xmlNode *import_element(XmlElement* element);
 };
 
 }  // namespace libxmljs

--- a/src/xml_namespace.cc
+++ b/src/xml_namespace.cc
@@ -76,7 +76,7 @@ XmlNamespace::XmlNamespace(xmlNs* node) : xml_obj(node)
         this->context = xml_obj->context;
         // a namespace must be created on a given node
         XmlDocument* doc = static_cast<XmlDocument*>(xml_obj->context->_private);
-        doc->ref();
+        doc->Ref();
     }
     else {
         this->context = NULL;
@@ -102,7 +102,7 @@ XmlNamespace::~XmlNamespace()
         if (this->context->_private != NULL) {
             // release the hold and allow the document to be freed
             XmlDocument* doc = static_cast<XmlDocument*>(this->context->_private);
-            doc->unref();
+            doc->Unref();
         }
         this->context = NULL;
     }

--- a/src/xml_node.h
+++ b/src/xml_node.h
@@ -12,11 +12,16 @@ public:
 
     xmlNode* xml_obj;
 
-    // boolean value to check if `xml_obj` was already freed
-    bool freed;
+    // reference to a parent XmlNode or XmlElement
+    xmlNode* ancestor;
 
-    // backup reference to the doc in case `xml_obj` was already freed
-    xmlDoc* doc;
+    // referencing functions
+    void ref_wrapped_ancestor(int unref = 0);
+    void unref_wrapped_ancestor();
+    xmlNode* get_wrapped_ancestor();
+    int refs() {
+        return refs_;
+    };
 
     explicit XmlNode(xmlNode* node);
     virtual ~XmlNode();
@@ -55,6 +60,12 @@ protected:
     v8::Local<v8::Value> get_type();
     v8::Local<v8::Value> to_string(int options = 0);
     void remove();
+    void add_child(xmlNode* child);
+    void add_prev_sibling(xmlNode* element);
+    void add_next_sibling(xmlNode* element);
+    void replace_element(xmlNode* element);
+    void replace_text(const char* content);
+    xmlNode *import_element(XmlNode* element);
 };
 
 }  // namespace libxmljs

--- a/test/element.js
+++ b/test/element.js
@@ -198,7 +198,7 @@ module.exports.replace = function(assert) {
 
   doc = libxml.parseXml(str);
   bar = doc.get('bar');
-  enchant = libxml.parseXml('<enchanted/>');
+  var enchant = libxml.parseXml('<enchanted/>');
   bar.replace(enchant.root());
   assert.equal(doc.root().toString(), '<foo>some <enchanted/> evening</foo>')
   assert.equal(doc.root().childNodes().length, 3);

--- a/test/z_memory_leak.js
+++ b/test/z_memory_leak.js
@@ -1,0 +1,42 @@
+var libxml = require('../index');
+
+if (!global.gc) {
+    throw new Error('must run with --expose_gc for memory management tests');
+}
+
+/*
+ * TODO: Possibly create a custom `nodeunit` test reporter (https://github.com/caolan/nodeunit#command-line-options)
+ *       that will run this check after each test. This would allow us to see exactly which test is causing a leak.
+ *
+ */
+
+// run this test last to check for any unfreed nodes
+module.exports.detect_leaks = function(assert) {
+    collectGarbage(5);
+    if (libxml.nodeCount() > 0) {
+        console.log('tests leak '+libxml.nodeCount()+' nodes');
+        assert.ok(false);
+    }
+    assert.done();
+}
+
+function collectGarbage(minCycles, maxCycles) {
+    minCycles = minCycles || 3;
+    maxCycles = maxCycles || 10;
+
+    var cycles = 0;
+    var freedRss = 0;
+    var usage = process.memoryUsage();
+    do {
+        global.gc();
+
+        var usageAfterGc = process.memoryUsage();
+        freedRss = usage.rss - usageAfterGc.rss;
+        usage = usageAfterGc;
+
+        cycles++;
+    }
+    while ((cycles < minCycles) || ((freedRss !== 0) && (cycles < maxCycles)));
+
+    return usage;
+}


### PR DESCRIPTION
Here's a new ref count strategy that works by Ref/Unrefing the closest wrapped ancestor available.

Benefits over #360:
 * We don't have to modify the libxml source code
 * We use only ObjectWrap::Ref/Unref for ref counting

@teleological I would really appreciate a review on this one. I think it may be less bug-prone than #360.