### PR TITLE
0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "Jeff Smick"
   ],
   "description": "libxml bindings for v8 javascript engine",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "scripts": {
     "test": "node --expose_gc ./node_modules/.bin/nodeunit test"
   },


### PR DESCRIPTION
Changes since 0.15.0:
* Document#type(), Document.fromHtml()
* Node#namespace(ns) returns node
* Node#namespaces(true) returns only locally-defined namespaces
* Comment nodes no longer escape content as XML
* Exposed xmlMemUsed as .memoryUsage()
* Fixed various memory issues