### PR TITLE
Baseurl for xml (as well as html)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-target=./build/Release/libxmljs.node
+target=./build/Release/xmljs.node
 
 all: $(target)
 

--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -235,7 +235,7 @@ NAN_METHOD(XmlDocument::ToString)
     if (xmlBufferLength(buf) > 0)
         ret = Nan::New<v8::String>((char*)xmlBufferContent(buf), xmlBufferLength(buf)).ToLocalChecked();
     xmlBufferFree(buf);
-    
+
     return info.GetReturnValue().Set(ret);
 }
 
@@ -317,7 +317,7 @@ xmlParserOption getParserOptions(v8::Local<v8::Object> props) {
     ret |= getParserOption(props, "cdata", XML_PARSE_NOCDATA, false);       // 16384: merge CDATA as text nodes
 
     ret |= getParserOption(props, "noxincnode", XML_PARSE_NOXINCNODE);      // 32768: do not generate XINCLUDE START/END nodes
-    ret |= getParserOption(props, "xinclude", XML_PARSE_NOXINCNODE, false); // 32768: do not generate XINCLUDE START/END nodes
+    ret |= getParserOption(props, "xincnode", XML_PARSE_NOXINCNODE, false); // 32768: do not generate XINCLUDE START/END nodes
 
     ret |= getParserOption(props, "compact", XML_PARSE_COMPACT);            // 65536: compact small text nodes; no modification of the tree allowed afterwards (will possibly crash if you try to modify the tree)
     /*ret |= getParserOption(props, "compact", HTML_PARSE_COMPACT , false);   // 65536: compact small text nodes*/
@@ -404,6 +404,9 @@ NAN_METHOD(XmlDocument::FromHtml)
     return info.GetReturnValue().Set(doc_handle);
 }
 
+// FIXME: this method is almost identical to FromHtml above.
+// The two should be refactored to use a common function for most
+// of the work
 NAN_METHOD(XmlDocument::FromXml)
 {
     Nan::HandleScope scope;
@@ -413,19 +416,41 @@ NAN_METHOD(XmlDocument::FromXml)
     xmlSetStructuredErrorFunc(reinterpret_cast<void *>(&errors),
             XmlSyntaxError::PushToArray);
 
-    xmlParserOption opts = getParserOptions(info[1]->ToObject());
+    v8::Local<v8::Object> options = info[1]->ToObject();
+    v8::Local<v8::Value>  baseUrlOpt  = options->Get(
+        Nan::New<v8::String>("baseUrl").ToLocalChecked());
+    v8::Local<v8::Value>  encodingOpt = options->Get(
+        Nan::New<v8::String>("encoding").ToLocalChecked());
+    v8::Local<v8::Value> excludeImpliedElementsOpt = options->Get(
+        Nan::New<v8::String>("excludeImpliedElements").ToLocalChecked());
 
+    // the base URL that will be used for this document
+    v8::String::Utf8Value baseUrl_(baseUrlOpt->ToString());
+    const char * baseUrl = *baseUrl_;
+    if (!baseUrlOpt->IsString()) {
+        baseUrl = NULL;
+    }
+
+    // the encoding to be used for this document
+    // (leave NULL for libxml to autodetect)
+    v8::String::Utf8Value encoding_(encodingOpt->ToString());
+    const char * encoding = *encoding_;
+    if (!encodingOpt->IsString()) {
+        encoding = NULL;
+    }
+
+    int opts = (int) getParserOptions(options);
     xmlDocPtr doc;
     if (!node::Buffer::HasInstance(info[0])) {
       // Parse a string
       v8::String::Utf8Value str(info[0]->ToString());
-      doc = xmlReadMemory(*str, str.length(), NULL, "UTF-8", opts);
+      doc = xmlReadMemory(*str, str.length(), baseUrl, "UTF-8", opts);
     }
     else {
       // Parse a buffer
       v8::Local<v8::Object> buf = info[0]->ToObject();
       doc = xmlReadMemory(node::Buffer::Data(buf), node::Buffer::Length(buf),
-                          NULL, NULL, opts);
+                          baseUrl, encoding, opts);
     }
 
     xmlSetStructuredErrorFunc(NULL, NULL);

--- a/test/fixtures/baseurl.dtd
+++ b/test/fixtures/baseurl.dtd
@@ -1,0 +1,3 @@
+<!ELEMENT example EMPTY>
+<!ATTLIST example msg CDATA "IMPLIED">
+<!ENTITY happy "Happy gardens forever!">

--- a/test/xml_parser.js
+++ b/test/xml_parser.js
@@ -55,6 +55,31 @@ module.exports.recoverable_parse = function(assert) {
     assert.done();
 };
 
+module.exports.baseurl_xml = function(assert) {
+    var str = '<!DOCTYPE example SYSTEM "baseurl.dtd">\n' +
+      '<example msg="&happy;"/>\n';
+
+    // First verify it fails when we don't give baseUrl
+    var doc = libxml.Document.fromXml(str, {
+      dtdvalid: true,
+      nonet: true,
+    });
+    assert.ok(doc.errors.length > 0);
+
+    // Now it should work
+    var doc = libxml.Document.fromXml(str, {
+      dtdvalid: true,
+      nonet: true,
+      baseUrl: __dirname + '/fixtures/example.xml',
+    });
+    assert.ok(!doc.errors || doc.errors.length == 0);
+
+    assert.done();
+};
+
+
+
+
 module.exports.fatal_error = function(assert) {
     var filename = __dirname + '/fixtures/errors/comment.xml';
     var str = fs.readFileSync(filename, 'utf8');


### PR DESCRIPTION
This PR comprises two changes. I'll describe them as line comments below.

The main purpose of this PR is to add the baseUrl option to FromXml. I noticed that this (and a few other options) were already added to FromHtml a long time ago, so I added them to FromXml in the same way.

The two methods are almost identical, and probably should be refactored to move the common code into a separate function that they both call. If it had been done that way originally, then users of FromXml would have benefited from these extra options added to FromHtml.

So, some of the changes were just for the purposes of harmonizing the FromHtml and FromXml methods. I didn't want to factor out into a separate function, though -- it seemed like too big a change. In lieu of that, I just tried to get the two functions to be as similar as possible.