### PR TITLE
builds with node 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ node_js:
     - iojs-2
     - iojs-3
     - 4
+    - 6
 
 addons:
     apt:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "bindings": "1.2.1",
-    "nan": "2.0.7"
+    "nan": "^2.0.7"
   },
   "devDependencies": {
     "nodeunit": "0.9.0"


### PR DESCRIPTION
For the just-released node.js 6.0.0 there was also an update to nan, 2.3.2. This PR loosens the dependency on nan so that a 6-compatible version can be pulled in.